### PR TITLE
[TASK] Add options property on HTMLSelectElement

### DIFF
--- a/cjs/html/select-element.js
+++ b/cjs/html/select-element.js
@@ -3,6 +3,7 @@ const {registerHTMLClass} = require('../shared/register-html-class.js');
 const {booleanAttribute} = require('../shared/attributes.js');
 
 const {HTMLElement} = require('./element.js');
+const {NodeList} = require('../interface/node-list.js');
 
 const tagName = 'select';
 
@@ -12,6 +13,20 @@ const tagName = 'select';
 class HTMLSelectElement extends HTMLElement {
   constructor(ownerDocument, localName = tagName) {
     super(ownerDocument, localName);
+  }
+
+  get options() {
+    let children = new NodeList;
+    let {firstElementChild} = this;
+    while (firstElementChild) {
+      if (firstElementChild.tagName === 'OPTGROUP') {
+        children = children.concat(firstElementChild.children);
+      } else {
+        children.push(firstElementChild);
+      }
+      firstElementChild = firstElementChild.nextElementSibling;
+    }
+    return children;
   }
 
   /* c8 ignore start */
@@ -26,3 +41,4 @@ class HTMLSelectElement extends HTMLElement {
 registerHTMLClass(tagName, HTMLSelectElement);
 
 exports.HTMLSelectElement = HTMLSelectElement;
+

--- a/esm/html/select-element.js
+++ b/esm/html/select-element.js
@@ -2,6 +2,7 @@ import {registerHTMLClass} from '../shared/register-html-class.js';
 import {booleanAttribute} from '../shared/attributes.js';
 
 import {HTMLElement} from './element.js';
+import {NodeList} from '../interface/node-list.js';
 
 const tagName = 'select';
 
@@ -11,6 +12,20 @@ const tagName = 'select';
 class HTMLSelectElement extends HTMLElement {
   constructor(ownerDocument, localName = tagName) {
     super(ownerDocument, localName);
+  }
+
+  get options() {
+    let children = new NodeList;
+    let {firstElementChild} = this;
+    while (firstElementChild) {
+      if (firstElementChild.tagName === 'OPTGROUP') {
+        children = children.concat(firstElementChild.children);
+      } else {
+        children.push(firstElementChild);
+      }
+      firstElementChild = firstElementChild.nextElementSibling;
+    }
+    return children;
   }
 
   /* c8 ignore start */
@@ -25,3 +40,4 @@ class HTMLSelectElement extends HTMLElement {
 registerHTMLClass(tagName, HTMLSelectElement);
 
 export {HTMLSelectElement};
+

--- a/test/html/select-element.js
+++ b/test/html/select-element.js
@@ -1,0 +1,16 @@
+const assert = require('../assert.js').for('HTMLSelectElement');
+
+const {parseHTML} = global[Symbol.for('linkedom')];
+
+let {document} = parseHTML('<select></select>');
+let {firstElementChild: select} = document;
+
+select.innerHTML = '<option></option>';
+assert(select.toString(), '<select><option></option></select>');
+
+
+({document} = parseHTML('<select><option></option><optgroup><option></option></optgroup></select>'));
+({firstElementChild: select} = document);
+assert(select.options.toString(), '<option></option>,<option></option>');
+assert(select.options.length, 2);
+


### PR DESCRIPTION
Hellow,

I'm currently implementing the linkedom package in my test environment and noticed, that the `HTMLSelectElement.options` property is missing (among a few other ones). I implemented an inaccurate version of it for my own purposes, "inaccurate" since it returns a `NodeList` instance instead of the correct `HTMLOptionsCollection` (living standard) / `HTMLCollection`. Furthermore, I included a test as well and at least on Ubuntu@WSL it writes a bunch of green 100's.

Thanks for your work, really appreciate it.

Sincerely,
Sam.
