### PR TITLE
Fast append on parsing

### DIFF
--- a/cjs/shared/parse-from-string.js
+++ b/cjs/shared/parse-from-string.js
@@ -1,9 +1,12 @@
 'use strict';
 const HTMLParser2 = require('htmlparser2');
 
-const {SVG_NAMESPACE} = require('./constants.js');
-const {CUSTOM_ELEMENTS} = require('./symbols.js');
+const {ELEMENT_NODE, SVG_NAMESPACE} = require('./constants.js');
+const {CUSTOM_ELEMENTS, PREV, END, NEXT, VALUE} = require('./symbols.js');
 const {keys} = require('./object.js');
+
+const {knownBoundaries, knownSiblings} = require('./utils.js');
+const {attributeChangedCallback, connectedCallback} = require('../interface/custom-element-registry.js');
 
 const {Parser} = HTMLParser2;
 
@@ -14,6 +17,25 @@ const {Parser} = HTMLParser2;
 // const voidSanitizer = html => html.replace(VOID_ELEMENTS, VOID_SANITIZER);
 
 let notParsing = true;
+
+const append = (self, node, active) => {
+  const end = self[END];
+  node.parentNode = self;
+  knownBoundaries(end[PREV], node, end);
+  if (active && node.nodeType === ELEMENT_NODE)
+    connectedCallback(node);
+  return node;
+};
+
+const attribute = (element, attribute, value, active) => {
+  attribute[VALUE] = value;
+  attribute.ownerElement = element;
+  knownSiblings(element, attribute, element[NEXT]);
+  if (attribute.name === 'class')
+    element.className = value;
+  if (active)
+    attributeChangedCallback(element, attribute.name, null, value);
+};
 
 const isNotParsing = () => notParsing;
 exports.isNotParsing = isNotParsing;
@@ -38,36 +60,36 @@ const parseFromString = (document, isHTML, markupLanguage) => {
       let create = true;
       if (isHTML) {
         if (ownerSVGElement) {
-          node = node.appendChild(document.createElementNS(SVG_NAMESPACE, name));
+          node = append(node, document.createElementNS(SVG_NAMESPACE, name), active);
           node.ownerSVGElement = ownerSVGElement;
           create = false;
         }
         else if (name === 'svg' || name === 'SVG') {
           ownerSVGElement = document.createElementNS(SVG_NAMESPACE, name);
-          node = node.appendChild(ownerSVGElement);
+          node = append(node, ownerSVGElement, active);
           create = false;
         }
         else if (active) {
           const ce = name.includes('-') ? name : (attributes.is || '');
           if (ce && registry.has(ce)) {
             const {Class} = registry.get(ce);
-            node = node.appendChild(new Class);
-            create = false;
+            node = append(node, new Class, active);
             delete attributes.is;
+            create = false;
           }
         }
       }
 
       if (create)
-        node = node.appendChild(document.createElement(name));
+        node = append(node, document.createElement(name), active);
 
       for (const name of keys(attributes))
-        node.setAttribute(name, attributes[name]);
+        attribute(node, document.createAttribute(name), attributes[name], active);
     },
 
     // #text, #comment
-    oncomment(data) { node.appendChild(document.createComment(data)); },
-    ontext(text) { node.appendChild(document.createTextNode(text)); },
+    oncomment(data) { append(node, document.createComment(data), active); },
+    ontext(text) { append(node, document.createTextNode(text), active); },
 
     // </tagName>
     onclosetag() {

--- a/esm/shared/parse-from-string.js
+++ b/esm/shared/parse-from-string.js
@@ -1,8 +1,11 @@
 import * as HTMLParser2 from 'htmlparser2';
 
-import {SVG_NAMESPACE} from './constants.js';
-import {CUSTOM_ELEMENTS} from './symbols.js';
+import {ELEMENT_NODE, SVG_NAMESPACE} from './constants.js';
+import {CUSTOM_ELEMENTS, PREV, END, NEXT, VALUE} from './symbols.js';
 import {keys} from './object.js';
+
+import {knownBoundaries, knownSiblings} from './utils.js';
+import {attributeChangedCallback, connectedCallback} from '../interface/custom-element-registry.js';
 
 const {Parser} = HTMLParser2;
 
@@ -13,6 +16,25 @@ const {Parser} = HTMLParser2;
 // const voidSanitizer = html => html.replace(VOID_ELEMENTS, VOID_SANITIZER);
 
 let notParsing = true;
+
+const append = (self, node, active) => {
+  const end = self[END];
+  node.parentNode = self;
+  knownBoundaries(end[PREV], node, end);
+  if (active && node.nodeType === ELEMENT_NODE)
+    connectedCallback(node);
+  return node;
+};
+
+const attribute = (element, attribute, value, active) => {
+  attribute[VALUE] = value;
+  attribute.ownerElement = element;
+  knownSiblings(element, attribute, element[NEXT]);
+  if (attribute.name === 'class')
+    element.className = value;
+  if (active)
+    attributeChangedCallback(element, attribute.name, null, value);
+};
 
 export const isNotParsing = () => notParsing;
 
@@ -36,36 +58,36 @@ export const parseFromString = (document, isHTML, markupLanguage) => {
       let create = true;
       if (isHTML) {
         if (ownerSVGElement) {
-          node = node.appendChild(document.createElementNS(SVG_NAMESPACE, name));
+          node = append(node, document.createElementNS(SVG_NAMESPACE, name), active);
           node.ownerSVGElement = ownerSVGElement;
           create = false;
         }
         else if (name === 'svg' || name === 'SVG') {
           ownerSVGElement = document.createElementNS(SVG_NAMESPACE, name);
-          node = node.appendChild(ownerSVGElement);
+          node = append(node, ownerSVGElement, active);
           create = false;
         }
         else if (active) {
           const ce = name.includes('-') ? name : (attributes.is || '');
           if (ce && registry.has(ce)) {
             const {Class} = registry.get(ce);
-            node = node.appendChild(new Class);
-            create = false;
+            node = append(node, new Class, active);
             delete attributes.is;
+            create = false;
           }
         }
       }
 
       if (create)
-        node = node.appendChild(document.createElement(name));
+        node = append(node, document.createElement(name), active);
 
       for (const name of keys(attributes))
-        node.setAttribute(name, attributes[name]);
+        attribute(node, document.createAttribute(name), attributes[name], active);
     },
 
     // #text, #comment
-    oncomment(data) { node.appendChild(document.createComment(data)); },
-    ontext(text) { node.appendChild(document.createTextNode(text)); },
+    oncomment(data) { append(node, document.createComment(data), active); },
+    ontext(text) { append(node, document.createTextNode(text), active); },
 
     // </tagName>
     onclosetag() {


### PR DESCRIPTION
Both nodes and attributes can skip a lot of checks while being appended from a fresh HTML parse.

The gain doesn't seem to be too relevant though, but there's surely less moving parts and it looks simpler this way.