### PR TITLE
Fix import of CJS Canvas module

### DIFF
--- a/esm/html/canvas-element.js
+++ b/esm/html/canvas-element.js
@@ -3,7 +3,7 @@ import {IMAGE} from '../shared/symbols.js';
 import {registerHTMLClass} from '../shared/register-html-class.js';
 import {numericAttribute} from '../shared/attributes.js';
 
-import * as Canvas from '../../commonjs/canvas.cjs';
+import Canvas from '../../commonjs/canvas.cjs';
 
 import {HTMLElement} from './element.js';
 


### PR DESCRIPTION
ESM is currently broken.

```
file:///Users/rarous/Projects/topmonks/hlidac-shopu/node_modules/linkedom/esm/html/canvas-element.js:20
    this[IMAGE] = createCanvas(300, 150);
                  ^

TypeError: createCanvas is not a function
    at new HTMLCanvasElement (file:///Users/rarous/Projects/topmonks/hlidac-shopu/node_modules/linkedom/esm/html/canvas-element.js:20:19)
    at createHTMLElement (file:///Users/rarous/Projects/topmonks/hlidac-shopu/node_modules/linkedom/esm/html/document.js:14:12)
    at EventTarget.createElement (file:///Users/rarous/Projects/topmonks/hlidac-shopu/node_modules/linkedom/esm/html/document.js:99:21)
    at Object.onopentag (file:///Users/rarous/Projects/topmonks/hlidac-shopu/node_modules/linkedom/esm/shared/parse-from-string.js:82:38)
    at Parser.onopentagend (/Users/rarous/Projects/topmonks/hlidac-shopu/node_modules/linkedom/node_modules/htmlparser2/lib/Parser.js:174:86)
    at Tokenizer.stateBeforeAttributeName (/Users/rarous/Projects/topmonks/hlidac-shopu/node_modules/linkedom/node_modules/htmlparser2/lib/Tokenizer.js:256:22)
    at Tokenizer.parse (/Users/rarous/Projects/topmonks/hlidac-shopu/node_modules/linkedom/node_modules/htmlparser2/lib/Tokenizer.js:635:22)
    at Tokenizer.write (/Users/rarous/Projects/topmonks/hlidac-shopu/node_modules/linkedom/node_modules/htmlparser2/lib/Tokenizer.js:123:14)
    at Parser.write (/Users/rarous/Projects/topmonks/hlidac-shopu/node_modules/linkedom/node_modules/htmlparser2/lib/Parser.js:338:24)
    at parseFromString (file:///Users/rarous/Projects/topmonks/hlidac-shopu/node_modules/linkedom/esm/shared/parse-from-string.js:104:11)
```
This patch fixes it on Node.js 15