### PR TITLE
Fix set outerHTML()

### DIFF
--- a/cjs/interface/element.js
+++ b/cjs/interface/element.js
@@ -197,7 +197,7 @@ class Element extends ParentNode {
   set outerHTML(html) {
     const template = this.ownerDocument.createElement('');
     template.innerHTML = html;
-    this.parentNode.replaceChild(template.firstElementChild, this);
+    this.replaceWith(...template.childNodes);
   }
   // </contentRelated>
 

--- a/cjs/interface/element.js
+++ b/cjs/interface/element.js
@@ -197,7 +197,7 @@ class Element extends ParentNode {
   set outerHTML(html) {
     const template = this.ownerDocument.createElement('');
     template.innerHTML = html;
-    this.replaceWith(...template.childNodes);
+    this.parentNode.replaceChild(template.firstElementChild, this);
   }
   // </contentRelated>
 

--- a/esm/interface/element.js
+++ b/esm/interface/element.js
@@ -198,7 +198,7 @@ export class Element extends ParentNode {
   set outerHTML(html) {
     const template = this.ownerDocument.createElement('');
     template.innerHTML = html;
-    this.parentNode.replaceChild(template.firstElementChild, this);
+    this.replaceWith(...template.childNodes);
   }
   // </contentRelated>
 

--- a/test/interface/element.js
+++ b/test/interface/element.js
@@ -1,0 +1,18 @@
+const assert = require('../assert.js').for('Text');
+
+const {parseHTML} = global[Symbol.for('linkedom')];
+
+const {document} = parseHTML('<html><div><span></span></div></html>');
+
+let div = document.querySelector('div');
+
+div.firstChild.outerHTML = 'hello';
+assert(div.firstChild.toString(), 'hello');
+
+div.innerHTML = '<span></span>'
+div.firstChild.outerHTML = '<p>hello</p>';
+assert(div.firstChild.toString(), '<p>hello</p>');
+
+div.innerHTML = '<span></span>'
+div.firstChild.outerHTML = '<p>hello</p> world';
+assert(div.toString(), '<div><p>hello</p> world</div>');


### PR DESCRIPTION
The new implementation should properly handle things like:

```
el.outerHTML = 'hello';
el.outerHTML = '<p>hello</p> world'
```

The current implementation will throw an exception for the first case and will set it to `'<p>hello</p>' ` instead of `'<p>hello</p> world'` in the 2nd case.`