### PR TITLE
unescape text nodes for innerHTML and outerHTML

### DIFF
--- a/cjs/interface/element.js
+++ b/cjs/interface/element.js
@@ -462,7 +462,7 @@ class Element extends ParentNode {
           break;
         case TEXT_NODE:
         case COMMENT_NODE:
-          out.push((isOpened ? '>' : '') + next);
+          out.push((isOpened ? '>' : '') + unescape(next));
           isOpened = false;
           break;
       }

--- a/esm/interface/element.js
+++ b/esm/interface/element.js
@@ -463,7 +463,7 @@ export class Element extends ParentNode {
           break;
         case TEXT_NODE:
         case COMMENT_NODE:
-          out.push((isOpened ? '>' : '') + next);
+          out.push((isOpened ? '>' : '') + unescape(next));
           isOpened = false;
           break;
       }

--- a/test/interface/element.js
+++ b/test/interface/element.js
@@ -9,7 +9,8 @@ let div = document.querySelector('div');
 div.firstChild.outerHTML = 'hello';
 assert(div.firstChild.toString(), 'hello');
 
-div.innerHTML = '<span></span>'
+div.innerHTML = '<span>"hi</span>';
+assert(div.firstChild.toString(), '<span>"hi</span>');
 div.firstChild.outerHTML = '<p>hello</p>';
 assert(div.firstChild.toString(), '<p>hello</p>');
 


### PR DESCRIPTION
`get innerHTML` and `get outerHTML` should unescape text nodes, so `<div>"hello"</div>` should not become `<div>&quot;hello&quot;</div>`