### PR TITLE
Fix attributes with empty values behaviour 

### DIFF
--- a/cjs/interface/attr.js
+++ b/cjs/interface/attr.js
@@ -1,7 +1,7 @@
 'use strict';
 const {ATTRIBUTE_NODE} = require('../shared/constants.js');
 const {CHANGED, VALUE} = require('../shared/symbols.js');
-const {String, ignoreCase} = require('../shared/utils.js');
+const {String} = require('../shared/utils.js');
 const {attrAsJSON} = require('../shared/jsdon.js');
 
 const {attributeChangedCallback: moAttributes} = require('./mutation-observer.js');
@@ -41,7 +41,7 @@ class Attr extends Node {
 
   toString() {
     const {name, [VALUE]: value} = this;
-    return value || !ignoreCase(this) ? `${name}="${value.replace(QUOTE, '&quot;')}"` : name;
+    return `${name}="${value.replace(QUOTE, '&quot;')}"`;
   }
 
   toJSON() {

--- a/esm/interface/attr.js
+++ b/esm/interface/attr.js
@@ -1,6 +1,6 @@
 import {ATTRIBUTE_NODE} from '../shared/constants.js';
 import {CHANGED, VALUE} from '../shared/symbols.js';
-import {String, ignoreCase} from '../shared/utils.js';
+import {String} from '../shared/utils.js';
 import {attrAsJSON} from '../shared/jsdon.js';
 
 import {attributeChangedCallback as moAttributes} from './mutation-observer.js';
@@ -40,7 +40,7 @@ export class Attr extends Node {
 
   toString() {
     const {name, [VALUE]: value} = this;
-    return value || !ignoreCase(this) ? `${name}="${value.replace(QUOTE, '&quot;')}"` : name;
+    return `${name}="${value.replace(QUOTE, '&quot;')}"`;
   }
 
   toJSON() {


### PR DESCRIPTION
The value of the attribute should be an empty string even if it's a boolean attribute with no value in the original document.
It's the standard behaviour in every browser and makes sense. Actually it's a very common use case. 