### PR TITLE
WIP: Add explicit code to make &nbsp;s come out correctly

### DIFF
--- a/esm/interface/element.js
+++ b/esm/interface/element.js
@@ -462,10 +462,18 @@ export class Element extends ParentNode {
           }
           break;
         case TEXT_NODE:
-        case COMMENT_NODE:
-          out.push((isOpened ? '>' : '') + next);
+        case COMMENT_NODE: {
+          let nextModified = next
+          // Special NBSP exemption, must always be escaped in output
+          if (next.toString().length === 1 && next.toString().charCodeAt(0) === 160) {
+            // console.log("^^^^^^^^ I would make next = " + escape(next)) // TODO: For some reason this comes out at '%A0'???
+            nextModified = '&nbsp;'
+          }
+
+          out.push((isOpened ? '>' : '') + nextModified);
           isOpened = false;
           break;
+        }
       }
     } while (next !== end);
     return out.join('');


### PR DESCRIPTION
I caught up with @WebReflection quickly and he encouraged me to make an MR for any WIP (even though it's ugly!)

# Problem

I found that when passing in `&nbsp;` what would come out was ' ' (character 160, a NBSP). Because the output is HTML I actually want the `&nbsp;` in the output.

# Solutions

I originally started looking at `html-escaper` for this, but I think really the ideal solution might be to just not convert &nbsp; to a character in the first place (at 'parsing time'?)

For now i'm looking for it in the output and replacing it, it's grimy but is helping me achieve my immediate goals

# Example

In: `<div>Foo&nbsp;&nbsp;&nbsp;&nbsp;Bar</div>`
Out (actual): `<div>Foo    Bar</div>` (spaces are char 160, nbsp characters, looks like github compresses them from 4 to 1 when showing here)
Out (expected): `<div>Foo&nbsp;&nbsp;&nbsp;&nbsp;Bar</div>`