### PR TITLE
Fix #62 - Follow specs for CharsetData un/escape

### DIFF
--- a/cjs/interface/comment.js
+++ b/cjs/interface/comment.js
@@ -1,8 +1,7 @@
 'use strict';
-const {escape} = require('html-escaper');
-
 const {COMMENT_NODE} = require('../shared/constants.js');
 const {VALUE} = require('../shared/symbols.js');
+const {escape} = require('../shared/text-escaper.js');
 
 const {CharacterData} = require('./character-data.js');
 

--- a/cjs/interface/element.js
+++ b/cjs/interface/element.js
@@ -1,8 +1,6 @@
 'use strict';
 // https://dom.spec.whatwg.org/#interface-element
 
-const {unescape} = require('html-escaper');
-
 const {
   ATTRIBUTE_NODE,
   COMMENT_NODE,
@@ -157,10 +155,7 @@ class Element extends ParentNode {
   }
 
   get innerHTML() {
-    const html = [];
-    for (const node of this.childNodes)
-      html.push(node.nodeType === ELEMENT_NODE ? node.toString() : unescape(node));
-    return html.join('');
+    return this.childNodes.join('');
   }
   set innerHTML(html) {
     const {ownerDocument} = this;

--- a/cjs/interface/text.js
+++ b/cjs/interface/text.js
@@ -1,8 +1,7 @@
 'use strict';
-const {escape} = require('html-escaper');
-
 const {TEXT_NODE} = require('../shared/constants.js');
 const {VALUE} = require('../shared/symbols.js');
+const {escape} = require('../shared/text-escaper.js');
 
 const {CharacterData} = require('./character-data.js');
 

--- a/cjs/shared/text-escaper.js
+++ b/cjs/shared/text-escaper.js
@@ -1,0 +1,24 @@
+'use strict';
+const {replace} = '';
+
+// escape
+const ca = /[<>&\xA0]/g;
+
+const esca = {
+  '\xA0': '&nbsp;',
+  '&': '&amp;',
+  '<': '&lt;',
+  '>': '&gt;'
+};
+
+const pe = m => esca[m];
+
+/**
+ * Safely escape HTML entities such as `&`, `<`, `>` only.
+ * @param {string} es the input to safely escape
+ * @returns {string} the escaped input, and it **throws** an error if
+ *  the input type is unexpected, except for boolean and numbers,
+ *  converted as string.
+ */
+const escape = es => replace.call(es, ca, pe);
+exports.escape = escape;

--- a/esm/interface/comment.js
+++ b/esm/interface/comment.js
@@ -1,7 +1,6 @@
-import {escape} from 'html-escaper';
-
 import {COMMENT_NODE} from '../shared/constants.js';
 import {VALUE} from '../shared/symbols.js';
+import {escape} from '../shared/text-escaper.js';
 
 import {CharacterData} from './character-data.js';
 

--- a/esm/interface/element.js
+++ b/esm/interface/element.js
@@ -1,7 +1,5 @@
 // https://dom.spec.whatwg.org/#interface-element
 
-import {unescape} from 'html-escaper';
-
 import {
   ATTRIBUTE_NODE,
   COMMENT_NODE,
@@ -159,10 +157,7 @@ export class Element extends ParentNode {
   }
 
   get innerHTML() {
-    const html = [];
-    for (const node of this.childNodes)
-      html.push(node.nodeType === ELEMENT_NODE ? node.toString() : unescape(node));
-    return html.join('');
+    return this.childNodes.join('');
   }
   set innerHTML(html) {
     const {ownerDocument} = this;

--- a/esm/interface/text.js
+++ b/esm/interface/text.js
@@ -1,7 +1,6 @@
-import {escape} from 'html-escaper';
-
 import {TEXT_NODE} from '../shared/constants.js';
 import {VALUE} from '../shared/symbols.js';
+import {escape} from '../shared/text-escaper.js';
 
 import {CharacterData} from './character-data.js';
 

--- a/esm/shared/text-escaper.js
+++ b/esm/shared/text-escaper.js
@@ -1,0 +1,22 @@
+const {replace} = '';
+
+// escape
+const ca = /[<>&\xA0]/g;
+
+const esca = {
+  '\xA0': '&nbsp;',
+  '&': '&amp;',
+  '<': '&lt;',
+  '>': '&gt;'
+};
+
+const pe = m => esca[m];
+
+/**
+ * Safely escape HTML entities such as `&`, `<`, `>` only.
+ * @param {string} es the input to safely escape
+ * @returns {string} the escaped input, and it **throws** an error if
+ *  the input type is unexpected, except for boolean and numbers,
+ *  converted as string.
+ */
+export const escape = es => replace.call(es, ca, pe);

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   },
   "dependencies": {
     "@ungap/event-target": "^0.2.2",
-    "css-select": "^4.1.2",
+    "css-select": "^4.1.3",
     "html-escaper": "^3.0.3",
     "htmlparser2": "^6.1.0",
     "uhyphen": "^0.1.0"

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "ascjs": "^5.0.1",
     "c8": "^7.7.2",
     "coveralls": "^3.1.0",
-    "eslint": "^7.27.0",
+    "eslint": "^7.28.0",
     "typescript": "^4.3.2"
   },
   "module": "./esm/index.js",

--- a/test/html/element.js
+++ b/test/html/element.js
@@ -124,9 +124,9 @@ node.removeAttributeNode(node.attributes[1]);
 node.innerHTML = '"hello"';
 assert(node.innerHTML, '"hello"');
 
-node.innerHTML = `<pre><code>echo &quot;&lt;table class=&#39;charts-css&#39;&gt;&quot;</code></pre>`;
-assert(node.innerHTML, `<pre><code>echo &quot;&lt;table class=&#39;charts-css&#39;&gt;&quot;</code></pre>`);
-assert(node.outerHTML, `<div b="2"><pre><code>echo &quot;&lt;table class=&#39;charts-css&#39;&gt;&quot;</code></pre></div>`);
+node.innerHTML = `<pre><code>echo &quot;&lt;table class='charts-css'&gt;&quot;</code></pre>`;
+assert(node.innerHTML, `<pre><code>echo "&lt;table class='charts-css'&gt;"</code></pre>`);
+assert(node.outerHTML, `<div b="2"><pre><code>echo "&lt;table class='charts-css'&gt;"</code></pre></div>`);
 
 node.innerHTML = '';
 node.setAttribute('class', 'a b c');

--- a/test/html/script-element.js
+++ b/test/html/script-element.js
@@ -12,9 +12,9 @@ assert(script.toString(), '<script what="ever">"</script>', 'text elements toStr
 // Unrelated
 const {head} = document;
 head.innerHTML = `<nope csp-hash="any">"</nope>`;
-assert(document.toString(), '<!DOCTYPE html><html><head><nope csp-hash="any">&quot;</nope></head></html>', 'Issue #1 - <nope> node');
+assert(document.toString(), '<!DOCTYPE html><html><head><nope csp-hash="any">"</nope></head></html>', 'Issue #1 - <nope> node');
 head.innerHTML = `<div csp-hash="any">"</div>`;
-assert(document.toString(), '<!DOCTYPE html><html><head><div csp-hash="any">&quot;</div></head></html>', 'Issue #1 - <div> node');
+assert(document.toString(), '<!DOCTYPE html><html><head><div csp-hash="any">"</div></head></html>', 'Issue #1 - <div> node');
 head.innerHTML = `<title csp-hash="any">"</title>`;
 assert(document.toString(), '<!DOCTYPE html><html><head><title csp-hash="any">"</title></head></html>', 'Issue #1 - <title> node');
 head.innerHTML = `<style csp-hash="any">"</style>`;

--- a/test/shared/text-escaper.js
+++ b/test/shared/text-escaper.js
@@ -1,0 +1,20 @@
+const BODY = '<body>Foo&nbsp;&quot;&nbsp;&quot;&nbsp;Bar</body>';
+const REBODY = BODY.replace(/&quot;/g, '"');
+const HTML = `<html id="html" class="live">${BODY}</html>`;
+const REHTML = `<html id="html" class="live">${REBODY}</html>`;
+
+const assert = require('../assert.js').for('Text Escaper');
+
+const {parseHTML} = global[Symbol.for('linkedom')];
+
+const {document} = parseHTML('<!DOCTYPE html>' + HTML);
+
+assert(document.documentElement.toString(), REHTML);
+
+document.documentElement.innerHTML = BODY;
+
+assert(document.documentElement.toString(), REHTML);
+
+document.documentElement.innerHTML = '<body>&amp;amp;</body>';
+assert(document.documentElement.toString(), `<html id="html" class="live"><body>&amp;amp;</body></html>`);
+

--- a/types/shared/text-escaper.d.ts
+++ b/types/shared/text-escaper.d.ts
@@ -1,0 +1,1 @@
+export function escape(es: string): string;


### PR DESCRIPTION
This MR does the following:

  * it keeps parsing of entities decoded
  * it escapes only `<`, `>`, and `&` in text and comments, plus `160` char as `&nbsp;`

This MR should close https://github.com/WebReflection/linkedom/pull/64 too.