### PR TITLE
Fix #67 - Moved global symbol into assert file

### DIFF
--- a/test/assert.js
+++ b/test/assert.js
@@ -1,3 +1,6 @@
+if (!(Symbol.for('linkedom') in global))
+  global[Symbol.for('linkedom')] = require('../cjs/index.js');
+
 module.exports = {
   for: Class => {
     console.log('\x1b[1m', Class.padEnd(60, ' '), '\x1b[0m');

--- a/test/html/anchor-element.js
+++ b/test/html/anchor-element.js
@@ -1,4 +1,4 @@
-const assert = require('../assert.js').for('HTMLButtonElement');
+const assert = require('../assert.js').for('HTMLAnchorElement');
 
 const {parseHTML} = global[Symbol.for('linkedom')];
 

--- a/test/index.js
+++ b/test/index.js
@@ -23,7 +23,6 @@ const test = folder => getFiles(folder).then(files => {
 });
 
 console.log(`\x1b[7m\x1b[1m ${'LinkeDOM'.padEnd(74)}\x1b[0m`);
-global[Symbol.for('linkedom')] = require('../cjs/index.js');
 test('xml')
 .then(() => test('svg'))
 .then(() => test('html'))


### PR DESCRIPTION
This MR makes it possible to run, as example:

```sh
npm run cjs && node test/html/anchor-element.js
```

So that one doesn't need to test the world when creating a new element or implementing a new feature.