### PR TITLE
Propagate document event to window

### DIFF
--- a/esm/interface/document.js
+++ b/esm/interface/document.js
@@ -210,6 +210,25 @@ export class Document extends NonElementParentNode {
     return document;
   }
 
+  dispatchEvent(event) {
+    const dispatched = super.dispatchEvent(event);
+
+    // intentionally simplified, specs imply way more code: https://dom.spec.whatwg.org/#event-path
+    if (dispatched && event.bubbles && !event.cancelBubble) {
+      const view = this.defaultView;
+      if (view && view.dispatchEvent) {
+        const options = {
+          bubbles: event.bubbles,
+          cancelable: event.cancelable,
+          composed: event.composed,
+        };
+        // in Node 16.5 the same event can't be used for another dispatch
+        return view.dispatchEvent(new event.constructor(event.type, options));
+      }
+    }
+    return dispatched;
+  }
+
   importNode(externalNode) {
     // important: keep the signature length as *one*
     // or it would behave like old IE or Edge with polyfills


### PR DESCRIPTION
Hi!

A code of mine broke, beacause it depends on an event propagated to the window from the document.
This PR fixes this behavior.

I also noticed that the capture and bubbling phase are not handled in dispatchEvent, I think that would be helpful to implement that logic, having some code depends on the order of the events.
Since I already done something like that, I could add it to this PR or maybe another one, to make things cleaner.