### PR TITLE
Type definition updates

### DIFF
--- a/cjs/interface/element.js
+++ b/cjs/interface/element.js
@@ -137,6 +137,9 @@ class Element extends ParentNode {
   // <contentRelated>
   get innerText() { return this.textContent; }
 
+  /**
+   * @returns {String}
+   */
   get textContent() {
     const text = [];
     let {[NEXT]: next, [END]: end} = this;

--- a/cjs/interface/node.js
+++ b/cjs/interface/node.js
@@ -84,10 +84,33 @@ class Node extends EventTarget {
   normalize() {}
   cloneNode() { return null; }
   contains() { return false; }
-  insertBefore() {}
-  appendChild() {}
-  replaceChild() {}
-  removeChild() {}
+  /**
+   * Inserts a node before a reference node as a child of this parent node.
+   * @param {Node} newNode The node to be inserted.
+   * @param {Node} referenceNode The node before which newNode is inserted. If this is null, then newNode is inserted at the end of node's child nodes.
+   * @returns The added child
+   */
+  // eslint-disable-next-line no-unused-vars
+  insertBefore(newNode, referenceNode) { return newNode }
+  /**
+   * Adds a node to the end of the list of children of this node.
+   * @param {Node} child The node to append to the given parent node.
+   * @returns The appended child.
+   */
+  appendChild(child) { return child }
+  /**
+   * Replaces a child node within this node
+   * @param {Node} newChild The new node to replace oldChild.
+   * @param {Node} oldChild The child to be replaced.
+   * @returns The replaced Node. This is the same node as oldChild.
+   */
+  replaceChild(newChild, oldChild) { return oldChild }
+  /**
+   * Removes a child node from the DOM.
+   * @param {Node} child A Node that is the child node to be removed from the DOM.
+   * @returns The removed node.
+   */
+  removeChild(child) { return child }
   toString() { return ''; }
   /* c8 ignore stop */
 

--- a/cjs/mixin/parent-node.js
+++ b/cjs/mixin/parent-node.js
@@ -81,6 +81,9 @@ class ParentNode extends Node {
     return children;
   }
 
+  /**
+   * @returns {NodeStruct | null}
+   */
   get firstChild() {
     let {[NEXT]: next, [END]: end} = this;
     while (next.nodeType === ATTRIBUTE_NODE)
@@ -88,6 +91,9 @@ class ParentNode extends Node {
     return next === end ? null : next;
   }
 
+  /**
+   * @returns {NodeStruct | null}
+   */
   get firstElementChild() {
     let {firstChild} = this;
     while (firstChild) {

--- a/cjs/mixin/parent-node.js
+++ b/cjs/mixin/parent-node.js
@@ -37,7 +37,7 @@ const insert = (parentNode, child, nodes) => {
     );
 };
 
-/** @typedef {{
+/** @typedef { import('../interface/element.js').Element & {
     [typeof NEXT]: NodeStruct,
     [typeof PREV]: NodeStruct,
     [typeof START]: NodeStruct,

--- a/esm/interface/element.js
+++ b/esm/interface/element.js
@@ -139,6 +139,9 @@ export class Element extends ParentNode {
   // <contentRelated>
   get innerText() { return this.textContent; }
 
+  /**
+   * @returns {String}
+   */
   get textContent() {
     const text = [];
     let {[NEXT]: next, [END]: end} = this;

--- a/esm/interface/node.js
+++ b/esm/interface/node.js
@@ -83,10 +83,33 @@ export class Node extends EventTarget {
   normalize() {}
   cloneNode() { return null; }
   contains() { return false; }
-  insertBefore() {}
-  appendChild() {}
-  replaceChild() {}
-  removeChild() {}
+  /**
+   * Inserts a node before a reference node as a child of this parent node.
+   * @param {Node} newNode The node to be inserted.
+   * @param {Node} referenceNode The node before which newNode is inserted. If this is null, then newNode is inserted at the end of node's child nodes.
+   * @returns The added child
+   */
+  // eslint-disable-next-line no-unused-vars
+  insertBefore(newNode, referenceNode) { return newNode }
+  /**
+   * Adds a node to the end of the list of children of this node.
+   * @param {Node} child The node to append to the given parent node.
+   * @returns The appended child.
+   */
+  appendChild(child) { return child }
+  /**
+   * Replaces a child node within this node
+   * @param {Node} newChild The new node to replace oldChild.
+   * @param {Node} oldChild The child to be replaced.
+   * @returns The replaced Node. This is the same node as oldChild.
+   */
+  replaceChild(newChild, oldChild) { return oldChild }
+  /**
+   * Removes a child node from the DOM.
+   * @param {Node} child A Node that is the child node to be removed from the DOM.
+   * @returns The removed node.
+   */
+  removeChild(child) { return child }
   toString() { return ''; }
   /* c8 ignore stop */
 

--- a/esm/mixin/parent-node.js
+++ b/esm/mixin/parent-node.js
@@ -36,7 +36,7 @@ const insert = (parentNode, child, nodes) => {
     );
 };
 
-/** @typedef {{
+/** @typedef { import('../interface/element.js').Element & {
     [typeof NEXT]: NodeStruct,
     [typeof PREV]: NodeStruct,
     [typeof START]: NodeStruct,

--- a/esm/mixin/parent-node.js
+++ b/esm/mixin/parent-node.js
@@ -80,6 +80,9 @@ export class ParentNode extends Node {
     return children;
   }
 
+  /**
+   * @returns {NodeStruct | null}
+   */
   get firstChild() {
     let {[NEXT]: next, [END]: end} = this;
     while (next.nodeType === ATTRIBUTE_NODE)
@@ -87,6 +90,9 @@ export class ParentNode extends Node {
     return next === end ? null : next;
   }
 
+  /**
+   * @returns {NodeStruct | null}
+   */
   get firstElementChild() {
     let {firstChild} = this;
     while (firstChild) {

--- a/types/interface/document.d.ts
+++ b/types/interface/document.d.ts
@@ -7,9 +7,9 @@ export class Document extends NonElementParentNode implements globalThis.Documen
      * @type {globalThis.Document['defaultView']}
      */
     get defaultView(): Window & typeof globalThis;
-    set doctype(arg: DocumentType | import("../mixin/parent-node.js").NodeStruct);
-    get doctype(): DocumentType | import("../mixin/parent-node.js").NodeStruct;
-    get documentElement(): import("../mixin/parent-node.js").NodeStruct;
+    set doctype(arg: any);
+    get doctype(): any;
+    get documentElement(): any;
     createAttribute(name: any): Attr;
     createComment(textContent: any): Comment;
     createDocumentFragment(): DocumentFragment;
@@ -23,7 +23,7 @@ export class Document extends NonElementParentNode implements globalThis.Documen
     importNode(externalNode: any, ...args: any[]): any;
     getElementsByTagNameNS(_: any, name: any): NodeList;
     createAttributeNS(_: any, name: any): Attr;
-    createElementNS(nsp: any, localName: any, options: any): Element;
+    createElementNS(nsp: any, localName: any, options: any): Element | SVGElement;
     [CUSTOM_ELEMENTS]: {
         active: boolean;
         registry: any;
@@ -40,15 +40,16 @@ export class Document extends NonElementParentNode implements globalThis.Documen
     [EVENT_TARGET]: EventTarget;
 }
 import { NonElementParentNode } from "../mixin/non-element-parent-node.js";
-import { DocumentType } from "./document-type.js";
 import { Attr } from "./attr.js";
 import { Comment } from "./comment.js";
 import { DocumentFragment } from "./document-fragment.js";
+import { DocumentType } from "./document-type.js";
 import { Element } from "./element.js";
 import { Range } from "./range.js";
 import { Text } from "./text.js";
 import { TreeWalker } from "./tree-walker.js";
 import { NodeList } from "./node-list.js";
+import { SVGElement } from "../svg/element.js";
 import { CUSTOM_ELEMENTS } from "../shared/symbols.js";
 import { MUTATION_OBSERVER } from "../shared/symbols.js";
 import { MIME } from "../shared/symbols.js";

--- a/types/interface/element.d.ts
+++ b/types/interface/element.d.ts
@@ -19,7 +19,7 @@ export class Element extends ParentNode implements globalThis.Element {
     get style(): any;
     set tabIndex(arg: number);
     get tabIndex(): number;
-    get innerText(): string;
+    get innerText(): any;
     set innerHTML(arg: string);
     get innerHTML(): string;
     set outerHTML(arg: string);

--- a/types/interface/image.d.ts
+++ b/types/interface/image.d.ts
@@ -109,8 +109,8 @@ export function ImageClass(ownerDocument: any): {
         nonce: any;
         readonly style: any;
         tabIndex: number;
-        readonly innerText: string;
-        textContent: string;
+        readonly innerText: any;
+        textContent: any;
         innerHTML: string;
         outerHTML: string;
         readonly attributes: any;
@@ -146,8 +146,8 @@ export function ImageClass(ownerDocument: any): {
         [STYLE]: any;
         readonly childNodes: import("./node-list.js").NodeList;
         readonly children: import("./node-list.js").NodeList;
-        readonly firstChild: import("../mixin/parent-node.js").NodeStruct;
-        readonly firstElementChild: import("../mixin/parent-node.js").NodeStruct;
+        readonly firstChild: any;
+        readonly firstElementChild: any;
         readonly lastChild: any;
         readonly lastElementChild: any;
         readonly childElementCount: number;

--- a/types/interface/node.d.ts
+++ b/types/interface/node.d.ts
@@ -38,10 +38,32 @@ export class Node extends EventTarget implements globalThis.Node {
     normalize(): void;
     cloneNode(): any;
     contains(): boolean;
-    insertBefore(): void;
-    appendChild(): void;
-    replaceChild(): void;
-    removeChild(): void;
+    /**
+     * Inserts a node before a reference node as a child of this parent node.
+     * @param {Node} newNode The node to be inserted.
+     * @param {Node} referenceNode The node before which newNode is inserted. If this is null, then newNode is inserted at the end of node's child nodes.
+     * @returns The added child
+     */
+    insertBefore(newNode: Node, referenceNode: Node): Node;
+    /**
+     * Adds a node to the end of the list of children of this node.
+     * @param {Node} child The node to append to the given parent node.
+     * @returns The appended child.
+     */
+    appendChild(child: Node): Node;
+    /**
+     * Replaces a child node within this node
+     * @param {Node} newChild The new node to replace oldChild.
+     * @param {Node} oldChild The child to be replaced.
+     * @returns The replaced Node. This is the same node as oldChild.
+     */
+    replaceChild(newChild: Node, oldChild: Node): Node;
+    /**
+     * Removes a child node from the DOM.
+     * @param {Node} child A Node that is the child node to be removed from the DOM.
+     * @returns The removed node.
+     */
+    removeChild(child: Node): Node;
     hasChildNodes(): boolean;
     isSameNode(node: any): boolean;
     compareDocumentPosition(target: any): number;

--- a/types/mixin/parent-node.d.ts
+++ b/types/mixin/parent-node.d.ts
@@ -8,7 +8,10 @@
 }} NodeStruct */
 export class ParentNode extends Node {
     get children(): NodeList;
-    get firstElementChild(): any;
+    /**
+     * @returns {NodeStruct | null}
+     */
+    get firstElementChild(): NodeStruct;
     get lastElementChild(): any;
     get childElementCount(): number;
     prepend(...nodes: any[]): void;

--- a/types/mixin/parent-node.d.ts
+++ b/types/mixin/parent-node.d.ts
@@ -1,4 +1,4 @@
-/** @typedef {{
+/** @typedef { import('../interface/element.js').Element & {
     [typeof NEXT]: NodeStruct,
     [typeof PREV]: NodeStruct,
     [typeof START]: NodeStruct,
@@ -8,7 +8,7 @@
 }} NodeStruct */
 export class ParentNode extends Node {
     get children(): NodeList;
-    get firstElementChild(): NodeStruct;
+    get firstElementChild(): any;
     get lastElementChild(): any;
     get childElementCount(): number;
     prepend(...nodes: any[]): void;
@@ -21,7 +21,7 @@ export class ParentNode extends Node {
     [PRIVATE]: any;
     [END]: NodeStruct;
 }
-export type NodeStruct = {
+export type NodeStruct = import('../interface/element.js').Element & {
     [typeof NEXT]: NodeStruct;
     [typeof PREV]: NodeStruct;
     [typeof START]: NodeStruct;

--- a/worker.js
+++ b/worker.js
@@ -11737,6 +11737,9 @@ class ParentNode extends Node$1 {
     return children;
   }
 
+  /**
+   * @returns {NodeStruct | null}
+   */
   get firstChild() {
     let {[NEXT]: next, [END]: end} = this;
     while (next.nodeType === ATTRIBUTE_NODE)
@@ -11744,6 +11747,9 @@ class ParentNode extends Node$1 {
     return next === end ? null : next;
   }
 
+  /**
+   * @returns {NodeStruct | null}
+   */
   get firstElementChild() {
     let {firstChild} = this;
     while (firstChild) {
@@ -12507,6 +12513,9 @@ class Element$1 extends ParentNode {
   // <contentRelated>
   get innerText() { return this.textContent; }
 
+  /**
+   * @returns {String}
+   */
   get textContent() {
     const text = [];
     let {[NEXT]: next, [END]: end} = this;

--- a/worker.js
+++ b/worker.js
@@ -9336,10 +9336,33 @@ class Node$1 extends DOMEventTarget {
   normalize() {}
   cloneNode() { return null; }
   contains() { return false; }
-  insertBefore() {}
-  appendChild() {}
-  replaceChild() {}
-  removeChild() {}
+  /**
+   * Inserts a node before a reference node as a child of this parent node.
+   * @param {Node} newNode The node to be inserted.
+   * @param {Node} referenceNode The node before which newNode is inserted. If this is null, then newNode is inserted at the end of node's child nodes.
+   * @returns The added child
+   */
+  // eslint-disable-next-line no-unused-vars
+  insertBefore(newNode, referenceNode) { return newNode }
+  /**
+   * Adds a node to the end of the list of children of this node.
+   * @param {Node} child The node to append to the given parent node.
+   * @returns The appended child.
+   */
+  appendChild(child) { return child }
+  /**
+   * Replaces a child node within this node
+   * @param {Node} newChild The new node to replace oldChild.
+   * @param {Node} oldChild The child to be replaced.
+   * @returns The replaced Node. This is the same node as oldChild.
+   */
+  replaceChild(newChild, oldChild) { return oldChild }
+  /**
+   * Removes a child node from the DOM.
+   * @param {Node} child A Node that is the child node to be removed from the DOM.
+   * @returns The removed node.
+   */
+  removeChild(child) { return child }
   toString() { return ''; }
   /* c8 ignore stop */
 

--- a/worker.js
+++ b/worker.js
@@ -11693,7 +11693,7 @@ const insert = (parentNode, child, nodes) => {
     );
 };
 
-/** @typedef {{
+/** @typedef { import('../interface/element.js').Element & {
     [typeof NEXT]: NodeStruct,
     [typeof PREV]: NodeStruct,
     [typeof START]: NodeStruct,


### PR DESCRIPTION
### What's the problem?

When using linkedom in a Typescript project, some functionality causes Typescript errors, despite that functionality working.  [Here's one example](https://github.com/WebReflection/linkedom/issues/99), another comes from accessing `innerText` on an element returned from a `querySelector`

### What have I done?

This PR updates type definitions for the methods  `insertBefore`, `appendChild`, `replaceChild`,`removeChild` on `Node`. 
 These updated to more closely match the functionality they provide, but still cause errors from the typescript compiler as they don't exactly match those provided by `globalThis.Node`.  After this change, the errors reported when implementing linkedom in another project go away.

This also updates the `NodeStruct` type to extend the `Element` type.  This enables accessing element properties from elements returned by `querySelector`.

The `NodeStruct` update appears to have confused the typescript compiler as some of the derived types were incorrectly converted to `any`.  To overcome this, I have added explicit return types to some other methods.