### PR TITLE
support window exports with WINDOW symbol

### DIFF
--- a/cjs/dom/parser.js
+++ b/cjs/dom/parser.js
@@ -5,6 +5,7 @@ const {parseFromString} = require('../shared/parse-from-string.js');
 const {HTMLDocument} = require('../html/document.js');
 const {SVGDocument} = require('../svg/document.js');
 const {XMLDocument} = require('../xml/document.js');
+const {MIME} = require('../shared/symbols.js');
 
 /**
  * @implements globalThis.DOMParser
@@ -12,17 +13,25 @@ const {XMLDocument} = require('../xml/document.js');
 class DOMParser {
 
   /** @typedef {{ "text/html": HTMLDocument, "image/svg+xml": SVGDocument, "text/xml": XMLDocument }} MimeToDoc */
+  /** @typedef {{ [x: symbol]: unknown, [MIME] : string }} Config */
   /**
    * @template {keyof MimeToDoc} MIME
    * @param {string} markupLanguage
-   * @param {MIME} mimeType
+   * @param {Config | string} config
    * @returns {MimeToDoc[MIME]}
    */
-  parseFromString(markupLanguage, mimeType) {
+  parseFromString(markupLanguage, config) {
+    const [mimeType, domOptions] = ((c) => {
+      if (typeof c === 'object') {
+        const {[MIME]: mime, ...rest} = c;
+        return [mime || 'text/html', rest]
+      }
+      return [c, {}]
+    })(config);
     let isHTML = false, document;
     if (mimeType === 'text/html') {
       isHTML = true;
-      document = new HTMLDocument;
+      document = new HTMLDocument(domOptions);
     }
     else if (mimeType === 'image/svg+xml')
       document = new SVGDocument;

--- a/cjs/index.js
+++ b/cjs/index.js
@@ -4,6 +4,8 @@ const {Document: _Document} = require('./interface/document.js');
 
 const {illegalConstructor} = require('./shared/facades.js');
 const {setPrototypeOf} = require('./shared/object.js');
+const {WINDOW, MIME} = require('./shared/symbols.js');
+
 (m => {
   exports.parseJSON = m.parseJSON;
   exports.toJSON = m.toJSON;
@@ -15,6 +17,7 @@ const {setPrototypeOf} = require('./shared/object.js');
 (require('./shared/html-classes.js'));
 
 exports.DOMParser = DOMParser;
+exports.WINDOW = WINDOW;
 
 (m => {
   exports.CustomEvent = m.CustomEvent;
@@ -32,10 +35,12 @@ exports.DOMParser = DOMParser;
   exports.NodeList = m.NodeList;
 })(require('./interface/node-list.js'));
 
-const parseHTML = html => (new DOMParser).parseFromString(
-  html, 'text/html'
-).defaultView;
-exports.parseHTML = parseHTML;
+const parseHTML = (html, global={}) => {
+  return (new DOMParser).parseFromString(
+    html, { [MIME]: 'text/html', [WINDOW]: global }
+  ).defaultView;
+}
+exports.parseHTML = parseHTML
 
 function Document() {
   illegalConstructor();

--- a/cjs/shared/symbols.js
+++ b/cjs/shared/symbols.js
@@ -78,3 +78,7 @@ exports.STYLE = STYLE;
 // used to define generic values
 const VALUE = Symbol('value');
 exports.VALUE = VALUE;
+
+// used in Document to set global values
+const WINDOW = Symbol('linkedomWindowProxy');
+exports.WINDOW = WINDOW;

--- a/esm/dom/parser.js
+++ b/esm/dom/parser.js
@@ -4,6 +4,7 @@ import {parseFromString} from '../shared/parse-from-string.js';
 import {HTMLDocument} from '../html/document.js';
 import {SVGDocument} from '../svg/document.js';
 import {XMLDocument} from '../xml/document.js';
+import {MIME} from '../shared/symbols.js';
 
 /**
  * @implements globalThis.DOMParser
@@ -11,17 +12,25 @@ import {XMLDocument} from '../xml/document.js';
 export class DOMParser {
 
   /** @typedef {{ "text/html": HTMLDocument, "image/svg+xml": SVGDocument, "text/xml": XMLDocument }} MimeToDoc */
+  /** @typedef {{ [x: symbol]: unknown, [MIME] : string }} Config */
   /**
    * @template {keyof MimeToDoc} MIME
    * @param {string} markupLanguage
-   * @param {MIME} mimeType
+   * @param {Config | string} config
    * @returns {MimeToDoc[MIME]}
    */
-  parseFromString(markupLanguage, mimeType) {
+  parseFromString(markupLanguage, config) {
+    const [mimeType, domOptions] = ((c) => {
+      if (typeof c === 'object') {
+        const {[MIME]: mime, ...rest} = c;
+        return [mime || 'text/html', rest]
+      }
+      return [c, {}]
+    })(config);
     let isHTML = false, document;
     if (mimeType === 'text/html') {
       isHTML = true;
-      document = new HTMLDocument;
+      document = new HTMLDocument(domOptions);
     }
     else if (mimeType === 'image/svg+xml')
       document = new SVGDocument;

--- a/esm/html/document.js
+++ b/esm/html/document.js
@@ -6,6 +6,7 @@ import {Document} from '../interface/document.js';
 import {NodeList} from '../interface/node-list.js';
 import {customElements} from '../interface/custom-element-registry.js';
 
+import {WINDOW} from '../shared/symbols.js';
 import {HTMLElement} from './element.js';
 
 const createHTMLElement = (ownerDocument, builtin, localName, options) => {
@@ -29,7 +30,7 @@ const createHTMLElement = (ownerDocument, builtin, localName, options) => {
 /**
  * @implements globalThis.HTMLDocument
  */
-export class HTMLDocument extends Document {
+class _HTMLDocument extends Document {
   constructor() { super('text/html'); }
 
   get all() {
@@ -101,4 +102,54 @@ export class HTMLDocument extends Document {
       element.setAttribute('is', options.is);
     return element;
   }
+}
+
+/** @typedef {{ [WINDOW] : Object }} Context */
+/**
+ * @constructor
+ * @param {Context} context
+ */
+export class HTMLDocument extends _HTMLDocument {
+
+  constructor (context = {}) {
+    super();
+    const useState = (target, name) => {
+      return ((_0, _1={}) => {
+        const g = (name in _1) ? _1 : _0;
+        return {
+          get: () => g[name],
+          set: (v) => (g[name] = v) || true,
+        }
+      })(target, context[WINDOW]);
+    };
+    this[WINDOW] = {
+      set: (target, name, value) => {
+        return useState(target, name).set(value);
+      },
+      get: (target, name) => {
+        if (name === 'window') {
+          return new Proxy(target.window, this[WINDOW]);
+        }
+        return useState(target, name).get();
+      }
+    }
+  }
+
+  get defaultView() {
+    return new Proxy(super.defaultView, this[WINDOW])
+  }
+
+  get location() {
+    return this.defaultView.location;
+  }
+
+  set location(location) {
+    this.defaultView.location = location;
+  }
+
+  get all() { return super.all } 
+  get head() { return super.head } 
+  get body() { return super.body } 
+  get title() { return super.title } 
+  set title(v) { super.title = v } 
 }

--- a/esm/index.js
+++ b/esm/index.js
@@ -3,12 +3,14 @@ import {Document as _Document} from './interface/document.js';
 
 import {illegalConstructor} from './shared/facades.js';
 import {setPrototypeOf} from './shared/object.js';
+import {WINDOW, MIME} from './shared/symbols.js';
+
 export {parseJSON, toJSON} from './shared/parse-json.js';
 
 export * from './shared/facades.js';
 export * from './shared/html-classes.js';
 
-export {DOMParser};
+export {DOMParser, WINDOW};
 
 export {CustomEvent} from './interface/custom-event.js';
 export {Event} from './interface/event.js';
@@ -16,9 +18,11 @@ export {EventTarget} from './interface/event-target.js';
 export {InputEvent} from './interface/input-event.js';
 export {NodeList} from './interface/node-list.js';
 
-export const parseHTML = html => (new DOMParser).parseFromString(
-  html, 'text/html'
-).defaultView;
+export const parseHTML = (html, global={}) => {
+  return (new DOMParser).parseFromString(
+    html, { [MIME]: 'text/html', [WINDOW]: global }
+  ).defaultView;
+}
 
 export function Document() {
   illegalConstructor();

--- a/esm/shared/symbols.js
+++ b/esm/shared/symbols.js
@@ -57,3 +57,6 @@ export const STYLE = Symbol('style');
 
 // used to define generic values
 export const VALUE = Symbol('value');
+
+// used in Document to set global values
+export const WINDOW = Symbol('linkedomWindowProxy');

--- a/test/html/global.js
+++ b/test/html/global.js
@@ -1,0 +1,115 @@
+const assert = require('../assert.js').for('HTMLDocument');
+
+const {parseHTML, WINDOW} = global[Symbol.for('linkedom')];
+
+const {Document, DOMParser, window, setTimeout, history, location} = parseHTML(`
+<!doctype html>
+<html>
+  <head><title>hello</title></head>
+</html>
+`, {
+  get history() {
+    return {
+      get location() { return {pathname: '/'}; }
+    };
+  },
+  get location() { return {pathname: '/'}; }
+});
+
+const clone = window.document.cloneNode(true);
+assert(clone.isConnected, true, 'document always connected');
+assert(JSON.stringify(clone), '[9,10,"html",1,"html",1,"head",1,"title",3,"hello",-4]');
+assert(clone.doctype.nodeType, 10);
+assert(clone.isEqualNode(clone), true, 'isEqualNode');
+assert(clone.isEqualNode(window.document), true, 'isEqualNode');
+assert(window.history.location.pathname, '/');
+assert(history.location.pathname, '/');
+assert(window.location.pathname, '/');
+assert(location.pathname, '/');
+
+let document = (new DOMParser).parseFromString('', {
+  mime: 'text/html',
+  [WINDOW]: {
+    get history() {
+      return {
+        get location() { return {pathname: '/'}; }
+      };
+    }
+  }
+});
+assert(document.doctype, null);
+assert(document.defaultView.history.location.pathname, '/');
+assert(document.defaultView.location, undefined);
+assert(document.location, undefined);
+assert(document.history, undefined);
+
+document.insertBefore(document.createElement('html'));
+assert(document.doctype, null);
+
+document.insertBefore(clone.doctype, document.firstChild);
+assert(document.doctype, clone.doctype);
+
+assert(setTimeout, global.setTimeout);
+
+try {
+  new Document;
+  assert(true, false, 'Document should be used as class');
+} catch (ok) {}
+
+document = (new DOMParser).parseFromString('<!DOCTYPE html><html />', {
+  [WINDOW]: {
+    location: {
+      pathname: '/'
+    }
+  } 
+});
+assert(document.title, '', 'no title');
+document.title = '"hello"';
+assert(document.title, '"hello"', 'title not escaped');
+assert(document.toString(), '<!DOCTYPE html><html><head><title>"hello"</title></head></html>');
+assert(document.body.tagName, 'BODY');
+
+assert(document.defaultView.location.hash, undefined);
+assert(document.defaultView.location.pathname, '/');
+assert(document.defaultView.history, undefined);
+assert(document.location.hash, undefined);
+assert(document.location.pathname, '/');
+
+document.location = {
+  pathname: '/url/file.html',
+  hash: '#hash-string'
+}
+assert(document.defaultView.location.pathname, '/url/file.html');
+assert(document.defaultView.location.hash, '#hash-string');
+assert(document.location.pathname, '/url/file.html');
+assert(document.location.hash, '#hash-string');
+assert(JSON.stringify(document.location), JSON.stringify({
+  pathname: '/url/file.html',
+  hash: '#hash-string',
+}));
+
+document.title = '&';
+assert(document.toString(), '<!DOCTYPE html><html><head><title>&</title></head><body></body></html>');
+
+assert(document.all.length, 4);
+assert(document.all[0], document.querySelector('html'));
+assert(document.all[1], document.querySelector('head'));
+assert(document.all[2], document.querySelector('title'));
+assert(document.all[3], document.querySelector('body'));
+
+// global listener
+let triggered = false;
+window.addEventListener('test', function once() {
+  triggered = true;
+  window.removeEventListener('test', once);
+});
+
+window.dispatchEvent(new window.Event('test'));
+assert(triggered, true);
+
+window.anyValue = 123;
+assert(window.anyValue, 123);
+window.addEventListener = window.removeEventListener = window.dispatchEvent = null;
+assert(window.addEventListener, null);
+
+assert(typeof window.performance.now(), 'number');

--- a/types/esm/dom/parser.d.ts
+++ b/types/esm/dom/parser.d.ts
@@ -3,17 +3,21 @@
  */
 export class DOMParser implements globalThis.DOMParser {
     /** @typedef {{ "text/html": HTMLDocument, "image/svg+xml": SVGDocument, "text/xml": XMLDocument }} MimeToDoc */
+    /** @typedef {{ [x: symbol]: unknown, [MIME] : string }} Config */
     /**
      * @template {keyof MimeToDoc} MIME
      * @param {string} markupLanguage
-     * @param {MIME} mimeType
+     * @param {Config | string} config
      * @returns {MimeToDoc[MIME]}
      */
     parseFromString<MIME extends keyof {
         "text/html": HTMLDocument;
         "image/svg+xml": SVGDocument;
         "text/xml": XMLDocument;
-    }>(markupLanguage: string, mimeType: MIME): {
+    }>(markupLanguage: string, config: string | {
+        [x: symbol]: unknown;
+        [MIME]: string;
+    }): {
         "text/html": HTMLDocument;
         "image/svg+xml": SVGDocument;
         "text/xml": XMLDocument;
@@ -22,3 +26,4 @@ export class DOMParser implements globalThis.DOMParser {
 import { HTMLDocument } from "../html/document.js";
 import { SVGDocument } from "../svg/document.js";
 import { XMLDocument } from "../xml/document.js";
+import { MIME } from "../shared/symbols.js";

--- a/types/esm/html/document.d.ts
+++ b/types/esm/html/document.d.ts
@@ -1,7 +1,24 @@
+/** @typedef {{ [WINDOW] : Object }} Context */
+/**
+ * @constructor
+ * @param {Context} context
+ */
+export class HTMLDocument extends _HTMLDocument {
+    constructor(context?: {});
+    set location(arg: any);
+    get location(): any;
+    [WINDOW]: {
+        set: (target: any, name: any, value: any) => any;
+        get: (target: any, name: any) => any;
+    };
+}
+export type Context = {
+    [WINDOW]: any;
+};
 /**
  * @implements globalThis.HTMLDocument
  */
-export class HTMLDocument extends Document implements globalThis.HTMLDocument {
+declare class _HTMLDocument extends Document implements globalThis.HTMLDocument {
     constructor();
     get all(): NodeList;
     /**
@@ -18,5 +35,7 @@ export class HTMLDocument extends Document implements globalThis.HTMLDocument {
      */
     get title(): HTMLTitleElement;
 }
+import { WINDOW } from "../shared/symbols.js";
 import { Document } from "../interface/document.js";
 import { NodeList } from "../interface/node-list.js";
+export {};

--- a/types/esm/index.d.ts
+++ b/types/esm/index.d.ts
@@ -1,12 +1,13 @@
 export function Document(): void;
 export * from "./shared/facades.js";
 export * from "./shared/html-classes.js";
-export { DOMParser };
 export { CustomEvent } from "./interface/custom-event.js";
 export { Event } from "./interface/event.js";
 export { EventTarget } from "./interface/event-target.js";
 export { InputEvent } from "./interface/input-event.js";
 export { NodeList } from "./interface/node-list.js";
-export function parseHTML(html: any): Window & typeof globalThis;
+export function parseHTML(html: any, global?: {}): any;
 import { DOMParser } from "./dom/parser.js";
+import { WINDOW } from "./shared/symbols.js";
+export { DOMParser, WINDOW };
 export { parseJSON, toJSON } from "./shared/parse-json.js";

--- a/types/esm/shared/symbols.d.ts
+++ b/types/esm/shared/symbols.d.ts
@@ -18,3 +18,4 @@ export const SHEET: unique symbol;
 export const START: unique symbol;
 export const STYLE: unique symbol;
 export const VALUE: unique symbol;
+export const WINDOW: unique symbol;


### PR DESCRIPTION
This closes Issue #103. This allows the `HTMLDocument` constructor to accept a special WINDOW  property that sets up lazy access of new properties for:
 - `defaultView` and `defaultView.window`
 -  such as `location` and `history`, or any arbitrary key.  
 
 If the user happens to provide the [special](https://codesandbox.io/s/window-and-document-0pngb?file=/src/index.ts) `location` key, then:
 - The `document.location` will match the `location` of `defaultView` and `defaultView.window`. 
 - Otherwise, the keys will only apply to `defaultView` and `defaultView.window`.

No existing test changed. Three examples run in a new file, [test/html/global.js](https://github.com/thejohnhoffer/linkedom/blob/fe502e177c5ebcc246e7f0c0c77b07c839976bdc/test/html/global.js).

## DOMParser history Example

```js
const {WINDOW} = global[Symbol.for('linkedom')];

let document = (new DOMParser).parseFromString('', {
  mime: 'text/html',
  [WINDOW]: {
    get history() {
      return {
        get location() { return {pathname: '/'}; }
      };
    }
  }
});

assert(document.defaultView.history.location.pathname, '/');
assert(document.defaultView.location, undefined);
```

##  parseHTML history and location Example

```js
const {window, history, location} = parseHTML(`
<!doctype html>
<html>                                 
  <head><title>hello</title></head>
</html>                                                
`, {                                                                                           
  get history() {                     
    return {
      get location() { return {pathname: '/'}; }      
    };                                              
  },                                            
  get location() { return {pathname: '/'}; }
});         

assert(history.location.pathname, '/'); 
assert(window.location.pathname, '/');                    
assert(location.pathname, '/');
```

## DOMParser mutable location Example

```js
document = (new DOMParser).parseFromString('<!DOCTYPE html><html />', {
  [WINDOW]: {      
    location: {    
      pathname: '/'
    }
  } 
});

assert(document.location.hash, undefined);
assert(document.location.pathname, '/');

document.location = {
  pathname: '/url/file.html',
  hash: '#hash-string'
}

assert(document.defaultView.location.pathname, '/url/file.html');
assert(document.defaultView.location.hash, '#hash-string');
assert(document.location.pathname, '/url/file.html');
assert(document.location.hash, '#hash-string');
```