### PR TITLE
fix: this within custom elements constructor is not the same as in method calls

### DIFF
--- a/cjs/html/element.js
+++ b/cjs/html/element.js
@@ -4,7 +4,7 @@ const {booleanAttribute, stringAttribute} = require('../shared/attributes.js');
 
 const {Event} = require('../interface/event.js');
 const {Element} = require('../interface/element.js');
-const {Classes, customElements} = require('../interface/custom-element-registry.js');
+const {Classes, customElements, upgradingElements } = require('../interface/custom-element-registry.js');
 
 const Level0 = new WeakMap;
 const level0 = {
@@ -32,8 +32,15 @@ class HTMLElement extends Element {
 
   constructor(ownerDocument = null, localName = '') {
     super(ownerDocument, localName);
+    const {constructor: Class, [END]: end} = this;
+    if (upgradingElements.has(Class)) {
+      const {element, values } = upgradingElements.get(Class);
+      upgradingElements.delete(Class);
+      for (const [key, value] of values)
+        element[key] = value;
+      return element;
+    }
     if (!ownerDocument) {
-      const {constructor: Class, [END]: end} = this;
       if (!Classes.has(Class))
         throw new Error('unable to initialize this Custom Element');
       const {ownerDocument, localName, options} = Classes.get(Class);

--- a/cjs/interface/custom-element-registry.js
+++ b/cjs/interface/custom-element-registry.js
@@ -11,6 +11,9 @@ exports.Classes = Classes;
 const customElements = new WeakMap;
 exports.customElements = customElements;
 
+const upgradingElements = new WeakMap;
+exports.upgradingElements = upgradingElements;
+
 const attributeChangedCallback = (element, attributeName, oldValue, newValue) => {
   if (
     reactive &&
@@ -68,24 +71,24 @@ exports.disconnectedCallback = disconnectedCallback;
 class CustomElementRegistry {
 
   /**
-   * @param {Document} ownerDocument 
+   * @param {Document} ownerDocument
    */
   constructor(ownerDocument) {
     /**
      * @private
      */
     this.ownerDocument = ownerDocument;
-  
+
     /**
      * @private
      */
     this.registry = new Map;
-  
+
     /**
      * @private
      */
     this.waiting = new Map;
-  
+
     /**
      * @private
      */
@@ -152,11 +155,11 @@ class CustomElementRegistry {
         for (const [key] of values)
           delete element[key];
 
-        setPrototypeOf(element, new Class(this.ownerDocument, ce));
+        setPrototypeOf(element, Class.prototype);
         customElements.set(element, {connected: isConnected});
 
-        for (const [key, value] of values)
-          element[key] = value;
+        upgradingElements.set(Class, { element, values });
+        new Class(this.ownerDocument, ce)
 
         for (const attr of attributes)
           element.setAttributeNode(attr);

--- a/esm/html/element.js
+++ b/esm/html/element.js
@@ -3,7 +3,7 @@ import {booleanAttribute, stringAttribute} from '../shared/attributes.js';
 
 import {Event} from '../interface/event.js';
 import {Element} from '../interface/element.js';
-import {Classes, customElements} from '../interface/custom-element-registry.js';
+import {Classes, customElements, upgradingElements } from '../interface/custom-element-registry.js';
 
 const Level0 = new WeakMap;
 const level0 = {
@@ -31,8 +31,15 @@ export class HTMLElement extends Element {
 
   constructor(ownerDocument = null, localName = '') {
     super(ownerDocument, localName);
+    const {constructor: Class, [END]: end} = this;
+    if (upgradingElements.has(Class)) {
+      const {element, values } = upgradingElements.get(Class);
+      upgradingElements.delete(Class);
+      for (const [key, value] of values)
+        element[key] = value;
+      return element;
+    }
     if (!ownerDocument) {
-      const {constructor: Class, [END]: end} = this;
       if (!Classes.has(Class))
         throw new Error('unable to initialize this Custom Element');
       const {ownerDocument, localName, options} = Classes.get(Class);

--- a/esm/interface/custom-element-registry.js
+++ b/esm/interface/custom-element-registry.js
@@ -8,6 +8,8 @@ export const Classes = new WeakMap;
 
 export const customElements = new WeakMap;
 
+export const upgradingElements = new WeakMap;
+
 export const attributeChangedCallback = (element, attributeName, oldValue, newValue) => {
   if (
     reactive &&
@@ -62,24 +64,24 @@ export const disconnectedCallback = element => {
 export class CustomElementRegistry {
 
   /**
-   * @param {Document} ownerDocument 
+   * @param {Document} ownerDocument
    */
   constructor(ownerDocument) {
     /**
      * @private
      */
     this.ownerDocument = ownerDocument;
-  
+
     /**
      * @private
      */
     this.registry = new Map;
-  
+
     /**
      * @private
      */
     this.waiting = new Map;
-  
+
     /**
      * @private
      */
@@ -146,11 +148,11 @@ export class CustomElementRegistry {
         for (const [key] of values)
           delete element[key];
 
-        setPrototypeOf(element, new Class(this.ownerDocument, ce));
+        setPrototypeOf(element, Class.prototype);
         customElements.set(element, {connected: isConnected});
 
-        for (const [key, value] of values)
-          element[key] = value;
+        upgradingElements.set(Class, { element, values });
+        new Class(this.ownerDocument, ce)
 
         for (const attr of attributes)
           element.setAttributeNode(attr);

--- a/test/interface/custom-element-registry.js
+++ b/test/interface/custom-element-registry.js
@@ -2,7 +2,7 @@ const assert = require('../assert.js').for('CustomElementRegistry');
 
 const {parseHTML} = global[Symbol.for('linkedom')];
 
-const {HTMLElement, HTMLButtonElement, HTMLTemplateElement, customElements, document} = parseHTML('<html></html>');
+const {HTMLElement, HTMLButtonElement, HTMLTemplateElement, customElements, document} = parseHTML('<html><body><custom-element></custom-element></body></html>');
 
 class CE extends HTMLElement {}
 
@@ -176,3 +176,18 @@ document.documentElement.appendChild(outer);
 
 assert(args.splice(0).join(','), 'connected: outer-test,connected: button[is="inner-button"]', 'inner builtin elements get connected too');
 assert(outer.querySelector('button').toString(), '<button is="inner-button" test="123">OK</button>', 'button with the correct content');
+
+
+customElements.define('custom-element', class extends CE {
+  constructor(props) {
+    super(props);
+    this.constructorThis = () => {
+      return this
+    }
+  }
+  isCurrentThisSameAsConstructorThis() {
+    return this === this.constructorThis();
+  }
+})
+
+assert(document.querySelector('custom-element').isCurrentThisSameAsConstructorThis(), true, 'constructor this same as method this')

--- a/types/esm/interface/custom-element-registry.d.ts
+++ b/types/esm/interface/custom-element-registry.d.ts
@@ -1,5 +1,6 @@
 export const Classes: WeakMap<object, any>;
 export const customElements: WeakMap<object, any>;
+export const upgradingElements: WeakMap<object, any>;
 export function attributeChangedCallback(element: any, attributeName: any, oldValue: any, newValue: any): void;
 export function connectedCallback(element: any): void;
 export function disconnectedCallback(element: any): void;

--- a/types/esm/shared/node.d.ts
+++ b/types/esm/shared/node.d.ts
@@ -6,7 +6,7 @@ export function parentElement({ parentNode }: {
     parentNode: any;
 }): any;
 export function previousSibling({ [PREV]: prev }: {
-    "__@PREV@38345": any;
+    "__@PREV@38381": any;
 }): any;
 export function nextSibling(node: any): any;
 import { PREV } from "./symbols.js";

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,12 +1,3 @@
 export function Document(): void;
-export * from "./shared/facades.js";
-export * from "./shared/html-classes.js";
 export { DOMParser };
-export { CustomEvent } from "./interface/custom-event.js";
-export { Event } from "./interface/event.js";
-export { EventTarget } from "./interface/event-target.js";
-export { InputEvent } from "./interface/input-event.js";
-export { NodeList } from "./interface/node-list.js";
-export function parseHTML(html: any): Window & typeof globalThis;
-import { DOMParser } from "./dom/parser.js";
-export { parseJSON, toJSON } from "./shared/parse-json.js";
+export function parseHTML(html: any): any;


### PR DESCRIPTION
During the initialization of a lit-element based custom element, some references to `this` are captured within the constructor. As the element becomes the prototype of an `HTMLElement` via `Object.setPropertyOf` the captured references to `this` are broken.

After spending some time researching how to fix this, I stumbled over a solution in the webcomponentsjs polyfill https://github.com/webcomponents/polyfills/blob/master/packages/scoped-custom-element-registry/src/scoped-custom-element-registry.js#L161

This PR is a close adaption of their approach and makes our SSR rendering work with lit-elements as well.