### PR TITLE
fix: custom elements cannot be upgraded without ownerDocument arg

### DIFF
--- a/cjs/html/element.js
+++ b/cjs/html/element.js
@@ -31,21 +31,27 @@ class HTMLElement extends Element {
   static get observedAttributes() { return []; }
 
   constructor(ownerDocument = null, localName = '') {
+    const passedDocument = ownerDocument;
+    let options;
+
     super(ownerDocument, localName);
-    if (ownerDocument) {
-      if (ownerDocument[UPGRADE]) {
-        const {element, values} = ownerDocument[UPGRADE];
-        ownerDocument[UPGRADE] = null;
-        for (const [key, value] of values)
-          element[key] = value;
-        return element;
-      }
-    }
-    else {
-      const {constructor: Class, [END]: end} = this;
+
+    if (!passedDocument) {
+      var {constructor: Class, [END]: end} = this;
       if (!Classes.has(Class))
         throw new Error('unable to initialize this Custom Element');
-      const {ownerDocument, localName, options} = Classes.get(Class);
+      ({ownerDocument, localName, options} = Classes.get(Class));
+    }
+
+    if (ownerDocument[UPGRADE]) {
+      const {element, values} = ownerDocument[UPGRADE];
+      ownerDocument[UPGRADE] = null;
+      for (const [key, value] of values)
+        element[key] = value;
+      return element;
+    }
+
+    if (!passedDocument) {
       this.ownerDocument = end.ownerDocument = ownerDocument;
       this.localName = localName;
       customElements.set(this, {connected: false});

--- a/esm/html/element.js
+++ b/esm/html/element.js
@@ -30,21 +30,27 @@ export class HTMLElement extends Element {
   static get observedAttributes() { return []; }
 
   constructor(ownerDocument = null, localName = '') {
+    const passedDocument = ownerDocument;
+    let options;
+
     super(ownerDocument, localName);
-    if (ownerDocument) {
-      if (ownerDocument[UPGRADE]) {
-        const {element, values} = ownerDocument[UPGRADE];
-        ownerDocument[UPGRADE] = null;
-        for (const [key, value] of values)
-          element[key] = value;
-        return element;
-      }
-    }
-    else {
-      const {constructor: Class, [END]: end} = this;
+
+    if (!passedDocument) {
+      var {constructor: Class, [END]: end} = this;
       if (!Classes.has(Class))
         throw new Error('unable to initialize this Custom Element');
-      const {ownerDocument, localName, options} = Classes.get(Class);
+      ({ownerDocument, localName, options} = Classes.get(Class));
+    }
+
+    if (ownerDocument[UPGRADE]) {
+      const {element, values} = ownerDocument[UPGRADE];
+      ownerDocument[UPGRADE] = null;
+      for (const [key, value] of values)
+        element[key] = value;
+      return element;
+    }
+
+    if (!passedDocument) {
       this.ownerDocument = end.ownerDocument = ownerDocument;
       this.localName = localName;
       customElements.set(this, {connected: false});

--- a/test/interface/custom-element-registry.js
+++ b/test/interface/custom-element-registry.js
@@ -2,7 +2,13 @@ const assert = require('../assert.js').for('CustomElementRegistry');
 
 const {parseHTML} = global[Symbol.for('linkedom')];
 
-const {HTMLElement, HTMLButtonElement, HTMLTemplateElement, customElements, document} = parseHTML('<html><body><custom-element></custom-element></body></html>');
+const {HTMLElement, HTMLButtonElement, HTMLTemplateElement, customElements, document} = parseHTML(`
+<html>
+<body>
+    <custom-element></custom-element>
+    <custom-element-without-constructor-args></custom-element-without-constructor-args>
+</body>
+</html>`);
 
 class CE extends HTMLElement {}
 
@@ -190,3 +196,12 @@ customElements.define('custom-element', class extends CE {
 })
 
 assert(document.querySelector('custom-element').isCurrentThisSameAsConstructorThis(), true, 'constructor this same as method this')
+
+const ceWithoutConstructorArgs = document.querySelector('custom-element-without-constructor-args');
+customElements.define('custom-element-without-constructor-args', class extends HTMLElement {
+  constructor() {
+    super();
+  }
+});
+
+assert(ceWithoutConstructorArgs.localName, 'custom-element-without-constructor-args', 'constructor without args')

--- a/worker.js
+++ b/worker.js
@@ -12943,21 +12943,27 @@ class HTMLElement extends Element$1 {
   static get observedAttributes() { return []; }
 
   constructor(ownerDocument = null, localName = '') {
+    const passedDocument = ownerDocument;
+    let options;
+
     super(ownerDocument, localName);
-    if (ownerDocument) {
-      if (ownerDocument[UPGRADE]) {
-        const {element, values} = ownerDocument[UPGRADE];
-        ownerDocument[UPGRADE] = null;
-        for (const [key, value] of values)
-          element[key] = value;
-        return element;
-      }
-    }
-    else {
-      const {constructor: Class, [END]: end} = this;
+
+    if (!passedDocument) {
+      var {constructor: Class, [END]: end} = this;
       if (!Classes.has(Class))
         throw new Error('unable to initialize this Custom Element');
-      const {ownerDocument, localName, options} = Classes.get(Class);
+      ({ownerDocument, localName, options} = Classes.get(Class));
+    }
+
+    if (ownerDocument[UPGRADE]) {
+      const {element, values} = ownerDocument[UPGRADE];
+      ownerDocument[UPGRADE] = null;
+      for (const [key, value] of values)
+        element[key] = value;
+      return element;
+    }
+
+    if (!passedDocument) {
       this.ownerDocument = end.ownerDocument = ownerDocument;
       this.localName = localName;
       customElements.set(this, {connected: false});


### PR DESCRIPTION
The current implementation fails to upgrade custom elements when no ownerDocument argument is passed, which is the case for most custom elements. 