### PR TITLE
Fix #113 - Add support for `CSSStyleDeclaration` property get, set, and remove

### DIFF
--- a/cjs/interface/css-style-declaration.js
+++ b/cjs/interface/css-style-declaration.js
@@ -82,6 +82,21 @@ class CSSStyleDeclaration extends Map {
     refs.get(this).setAttribute('style', value);
   }
 
+  getPropertyValue(name) {
+    const self = this[PRIVATE];
+    return handler.get(self, name);
+  }
+
+  setProperty(name, value) {
+    const self = this[PRIVATE];
+    handler.set(self, name, value);
+  }
+
+  removeProperty(name) {
+    const self = this[PRIVATE];
+    handler.set(self, name, null);
+  }
+
   [Symbol.iterator]() {
     const keys = getKeys(this[PRIVATE]);
     const {length} = keys;

--- a/esm/interface/css-style-declaration.js
+++ b/esm/interface/css-style-declaration.js
@@ -81,6 +81,21 @@ export class CSSStyleDeclaration extends Map {
     refs.get(this).setAttribute('style', value);
   }
 
+  getPropertyValue(name) {
+    const self = this[PRIVATE];
+    return handler.get(self, name);
+  }
+
+  setProperty(name, value) {
+    const self = this[PRIVATE];
+    handler.set(self, name, value);
+  }
+
+  removeProperty(name) {
+    const self = this[PRIVATE];
+    handler.set(self, name, null);
+  }
+
   [Symbol.iterator]() {
     const keys = getKeys(this[PRIVATE]);
     const {length} = keys;

--- a/test/interface/css-style-declaration.js
+++ b/test/interface/css-style-declaration.js
@@ -28,3 +28,9 @@ assert(node.toString(), '<div></div>', 'setter as null');
 node.id = '';
 node.className = '';
 assert(node.toString(), '<div></div>', 'setter as null');
+
+node.style.setProperty('background-color', 'purple');
+assert(node.toString(), '<div style="background-color:purple"></div>', 'setProperty');
+assert(node.style.getPropertyValue('background-color'), 'purple', 'getPropertyValue');
+node.style.removeProperty('background-color')
+assert(node.toString(), '<div></div>', 'removeProperty');

--- a/types/esm/interface/css-style-declaration.d.ts
+++ b/types/esm/interface/css-style-declaration.d.ts
@@ -5,6 +5,9 @@ export class CSSStyleDeclaration extends Map<any, any> implements globalThis.CSS
     constructor(element: any);
     set cssText(arg: string);
     get cssText(): string;
+    getPropertyValue(name: any): any;
+    setProperty(name: any, value: any): void;
+    removeProperty(name: any): void;
     get [PRIVATE](): CSSStyleDeclaration;
 }
 import { PRIVATE } from "../shared/symbols.js";

--- a/worker.js
+++ b/worker.js
@@ -12246,6 +12246,21 @@ class CSSStyleDeclaration$1 extends Map {
     refs.get(this).setAttribute('style', value);
   }
 
+  getPropertyValue(name) {
+    const self = this[PRIVATE];
+    return handler$1.get(self, name);
+  }
+
+  setProperty(name, value) {
+    const self = this[PRIVATE];
+    handler$1.set(self, name, value);
+  }
+
+  removeProperty(name) {
+    const self = this[PRIVATE];
+    handler$1.set(self, name, null);
+  }
+
   [Symbol.iterator]() {
     const keys = getKeys(this[PRIVATE]);
     const {length} = keys;


### PR DESCRIPTION
Add support for `CSSStyleDeclaration` property get, set, and remove:

 - [`CSSStyleDeclaration.getPropertyValue()`](https://developer.mozilla.org/en-US/docs/Web/API/CSSStyleDeclaration/getPropertyValue)
 - [`CSSStyleDeclaration.setProperty()`](https://developer.mozilla.org/en-US/docs/Web/API/CSSStyleDeclaration/setProperty)
 -  [`CSSStyleDeclaration.removeProperty()`](https://developer.mozilla.org/en-US/docs/Web/API/CSSStyleDeclaration/removeProperty)
 
Fix https://github.com/WebReflection/linkedom/issues/113