### PR TITLE
support shadow root nested custom elements

### DIFF
--- a/cjs/interface/custom-element-registry.js
+++ b/cjs/interface/custom-element-registry.js
@@ -38,7 +38,7 @@ const triggerConnected = createTrigger('connectedCallback', true);
 const connectedCallback = element => {
   if (reactive) {
     triggerConnected(element);
-    let {[NEXT]: next, [END]: end} = element;
+    let {[NEXT]: next, [END]: end} = element.shadowRoot || element;
     while (next !== end) {
       if (next.nodeType === ELEMENT_NODE)
         triggerConnected(next);
@@ -52,7 +52,7 @@ const triggerDisconnected = createTrigger('disconnectedCallback', false);
 const disconnectedCallback = element => {
   if (reactive) {
     triggerDisconnected(element);
-    let {[NEXT]: next, [END]: end} = element;
+    let {[NEXT]: next, [END]: end} = element.shadowRoot || element;
     while (next !== end) {
       if (next.nodeType === ELEMENT_NODE)
         triggerDisconnected(next);

--- a/cjs/interface/custom-element-registry.js
+++ b/cjs/interface/custom-element-registry.js
@@ -2,6 +2,7 @@
 const {ELEMENT_NODE} = require('../shared/constants.js');
 const {END, NEXT, UPGRADE} = require('../shared/symbols.js');
 const {entries, setPrototypeOf} = require('../shared/object.js');
+const {shadowRoots} = require('../shared/shadow-roots.js');
 
 let reactive = false;
 
@@ -38,7 +39,9 @@ const triggerConnected = createTrigger('connectedCallback', true);
 const connectedCallback = element => {
   if (reactive) {
     triggerConnected(element);
-    let {[NEXT]: next, [END]: end} = element.shadowRoot || element;
+    if (shadowRoots.has(element))
+      element = shadowRoots.get(element).shadowRoot;
+    let {[NEXT]: next, [END]: end} = element;
     while (next !== end) {
       if (next.nodeType === ELEMENT_NODE)
         triggerConnected(next);
@@ -52,7 +55,9 @@ const triggerDisconnected = createTrigger('disconnectedCallback', false);
 const disconnectedCallback = element => {
   if (reactive) {
     triggerDisconnected(element);
-    let {[NEXT]: next, [END]: end} = element.shadowRoot || element;
+    if (shadowRoots.has(element))
+      element = shadowRoots.get(element).shadowRoot;
+    let {[NEXT]: next, [END]: end} = element;
     while (next !== end) {
       if (next.nodeType === ELEMENT_NODE)
         triggerDisconnected(next);

--- a/cjs/interface/element.js
+++ b/cjs/interface/element.js
@@ -26,6 +26,7 @@ const {
 
 const {elementAsJSON} = require('../shared/jsdon.js');
 const {matches, prepareMatch} = require('../shared/matches.js');
+const {shadowRoots} = require('../shared/shadow-roots.js');
 
 const {isConnected, parentElement, previousSibling, nextSibling} = require('../shared/node.js');
 const {previousElementSibling, nextElementSibling} = require('../mixin/non-document-type-child-node.js');
@@ -65,7 +66,6 @@ const isVoid = ({localName, ownerDocument}) => {
   return ownerDocument[MIME].voidElements.test(localName);
 };
 
-const shadowRoots = new WeakMap;
 // </utils>
 
 /**

--- a/cjs/interface/element.js
+++ b/cjs/interface/element.js
@@ -296,7 +296,7 @@ class Element extends ParentNode {
       throw new Error('operation not supported');
     // TODO: shadowRoot should be likely a specialized class that extends DocumentFragment
     //       but until DSD is out, I am not sure I should spend time on this.
-    const shadowRoot = new ShadowRoot(this.ownerDocument);
+    const shadowRoot = new ShadowRoot(this);
     shadowRoot.append(...this.childNodes);
     shadowRoots.set(this, {
       mode: init.mode,

--- a/cjs/interface/shadow-root.js
+++ b/cjs/interface/shadow-root.js
@@ -7,8 +7,9 @@ const {NonElementParentNode} = require('../mixin/non-element-parent-node.js');
  * @implements globalThis.ShadowRoot
  */
 class ShadowRoot extends NonElementParentNode {
-  constructor(ownerDocument) {
-    super(ownerDocument, '#shadow-root', DOCUMENT_FRAGMENT_NODE);
+  constructor(host) {
+    super(host.ownerDocument, '#shadow-root', DOCUMENT_FRAGMENT_NODE);
+    this.host = host;
   }
 
   get innerHTML() {

--- a/cjs/shared/node.js
+++ b/cjs/shared/node.js
@@ -14,7 +14,7 @@ const isConnected = ({ownerDocument, parentNode}) => {
   while (parentNode) {
     if (parentNode === ownerDocument)
       return true;
-    parentNode = parentNode.parentNode;
+    parentNode = parentNode.parentNode || parentNode.host;
   }
   return false;
 };

--- a/cjs/shared/shadow-roots.js
+++ b/cjs/shared/shadow-roots.js
@@ -1,0 +1,3 @@
+'use strict';
+const shadowRoots = new WeakMap;
+exports.shadowRoots = shadowRoots;

--- a/esm/interface/custom-element-registry.js
+++ b/esm/interface/custom-element-registry.js
@@ -34,7 +34,7 @@ const triggerConnected = createTrigger('connectedCallback', true);
 export const connectedCallback = element => {
   if (reactive) {
     triggerConnected(element);
-    let {[NEXT]: next, [END]: end} = element;
+    let {[NEXT]: next, [END]: end} = element.shadowRoot || element;
     while (next !== end) {
       if (next.nodeType === ELEMENT_NODE)
         triggerConnected(next);
@@ -47,7 +47,7 @@ const triggerDisconnected = createTrigger('disconnectedCallback', false);
 export const disconnectedCallback = element => {
   if (reactive) {
     triggerDisconnected(element);
-    let {[NEXT]: next, [END]: end} = element;
+    let {[NEXT]: next, [END]: end} = element.shadowRoot || element;
     while (next !== end) {
       if (next.nodeType === ELEMENT_NODE)
         triggerDisconnected(next);

--- a/esm/interface/custom-element-registry.js
+++ b/esm/interface/custom-element-registry.js
@@ -1,6 +1,7 @@
 import {ELEMENT_NODE} from '../shared/constants.js';
 import {END, NEXT, UPGRADE} from '../shared/symbols.js';
 import {entries, setPrototypeOf} from '../shared/object.js';
+import {shadowRoots} from '../shared/shadow-roots.js';
 
 let reactive = false;
 
@@ -34,7 +35,9 @@ const triggerConnected = createTrigger('connectedCallback', true);
 export const connectedCallback = element => {
   if (reactive) {
     triggerConnected(element);
-    let {[NEXT]: next, [END]: end} = element.shadowRoot || element;
+    if (shadowRoots.has(element))
+      element = shadowRoots.get(element).shadowRoot;
+    let {[NEXT]: next, [END]: end} = element;
     while (next !== end) {
       if (next.nodeType === ELEMENT_NODE)
         triggerConnected(next);
@@ -47,7 +50,9 @@ const triggerDisconnected = createTrigger('disconnectedCallback', false);
 export const disconnectedCallback = element => {
   if (reactive) {
     triggerDisconnected(element);
-    let {[NEXT]: next, [END]: end} = element.shadowRoot || element;
+    if (shadowRoots.has(element))
+      element = shadowRoots.get(element).shadowRoot;
+    let {[NEXT]: next, [END]: end} = element;
     while (next !== end) {
       if (next.nodeType === ELEMENT_NODE)
         triggerDisconnected(next);

--- a/esm/interface/element.js
+++ b/esm/interface/element.js
@@ -28,6 +28,7 @@ import {
 
 import {elementAsJSON} from '../shared/jsdon.js';
 import {matches, prepareMatch} from '../shared/matches.js';
+import {shadowRoots} from '../shared/shadow-roots.js';
 
 import {isConnected, parentElement, previousSibling, nextSibling} from '../shared/node.js';
 import {previousElementSibling, nextElementSibling} from '../mixin/non-document-type-child-node.js';
@@ -67,7 +68,6 @@ const isVoid = ({localName, ownerDocument}) => {
   return ownerDocument[MIME].voidElements.test(localName);
 };
 
-const shadowRoots = new WeakMap;
 // </utils>
 
 /**

--- a/esm/interface/element.js
+++ b/esm/interface/element.js
@@ -298,7 +298,7 @@ export class Element extends ParentNode {
       throw new Error('operation not supported');
     // TODO: shadowRoot should be likely a specialized class that extends DocumentFragment
     //       but until DSD is out, I am not sure I should spend time on this.
-    const shadowRoot = new ShadowRoot(this.ownerDocument);
+    const shadowRoot = new ShadowRoot(this);
     shadowRoot.append(...this.childNodes);
     shadowRoots.set(this, {
       mode: init.mode,

--- a/esm/interface/shadow-root.js
+++ b/esm/interface/shadow-root.js
@@ -6,8 +6,9 @@ import {NonElementParentNode} from '../mixin/non-element-parent-node.js';
  * @implements globalThis.ShadowRoot
  */
 export class ShadowRoot extends NonElementParentNode {
-  constructor(ownerDocument) {
-    super(ownerDocument, '#shadow-root', DOCUMENT_FRAGMENT_NODE);
+  constructor(host) {
+    super(host.ownerDocument, '#shadow-root', DOCUMENT_FRAGMENT_NODE);
+    this.host = host;
   }
 
   get innerHTML() {

--- a/esm/shared/node.js
+++ b/esm/shared/node.js
@@ -13,7 +13,7 @@ export const isConnected = ({ownerDocument, parentNode}) => {
   while (parentNode) {
     if (parentNode === ownerDocument)
       return true;
-    parentNode = parentNode.parentNode;
+    parentNode = parentNode.parentNode || parentNode.host;
   }
   return false;
 };

--- a/esm/shared/shadow-roots.js
+++ b/esm/shared/shadow-roots.js
@@ -1,0 +1,1 @@
+export const shadowRoots = new WeakMap;

--- a/test/interface/custom-element-registry.js
+++ b/test/interface/custom-element-registry.js
@@ -166,14 +166,28 @@ outer.attachShadow({ mode: "open" });
 outer.shadowRoot.innerHTML = '<div>OK<inner-test>OK</inner-test>OK<inner-test>OK</inner-test>OK</div><inner-test>OK</inner-test>';
 document.documentElement.appendChild(outer);
 
-assert(args.splice(0).join(','), 'connected: outer-test,connected: inner-test,connected: inner-test,connected: inner-test', 'inner elements of shadow roots get connected too');
+assert(args.splice(0).join(','), 'connected: outer-test,connected: inner-test,connected: inner-test,connected: inner-test', 'inner elements of open shadow roots get connected too');
 
 outer.remove();
 
-assert(args.splice(0).join(','), 'disconnected: outer-test,disconnected: inner-test,disconnected: inner-test,disconnected: inner-test', 'inner elements of shadow roots get disconnected too');
+assert(args.splice(0).join(','), 'disconnected: outer-test,disconnected: inner-test,disconnected: inner-test,disconnected: inner-test', 'inner elements of open shadow roots get disconnected too');
 
 outer.remove();
-assert(args.length, 0, 'should not trigger disconnected again for shadow roots');
+assert(args.length, 0, 'should not trigger disconnected again for open shadow roots');
+
+outer = document.createElement('outer-test');
+const shadowRoot = outer.attachShadow({ mode: "closed" });
+shadowRoot.innerHTML = '<div>OK<inner-test>OK</inner-test>OK<inner-test>OK</inner-test>OK</div><inner-test>OK</inner-test>';
+document.documentElement.appendChild(outer);
+
+assert(args.splice(0).join(','), 'connected: outer-test,connected: inner-test,connected: inner-test,connected: inner-test', 'inner elements of closed shadow roots get connected too');
+
+outer.remove();
+
+assert(args.splice(0).join(','), 'disconnected: outer-test,disconnected: inner-test,disconnected: inner-test,disconnected: inner-test', 'inner elements of closed shadow roots get disconnected too');
+
+outer.remove();
+assert(args.length, 0, 'should not trigger disconnected again for closed shadow roots');
 
 outer = document.createElement('outer-test');
 customElements.define('inner-button', class extends HTMLButtonElement {

--- a/test/interface/custom-element-registry.js
+++ b/test/interface/custom-element-registry.js
@@ -161,6 +161,21 @@ assert(args.splice(0).join(','), 'disconnected: outer-test,disconnected: inner-t
 outer.remove();
 assert(args.length, 0, 'should not trigger disconnected again');
 
+outer = document.createElement('outer-test');
+outer.attachShadow({ mode: "open" });
+outer.shadowRoot.innerHTML = '<div>OK<inner-test>OK</inner-test>OK<inner-test>OK</inner-test>OK</div><inner-test>OK</inner-test>';
+document.documentElement.appendChild(outer);
+
+assert(args.splice(0).join(','), 'connected: outer-test,connected: inner-test,connected: inner-test,connected: inner-test', 'inner elements of shadow roots get connected too');
+
+outer.remove();
+
+assert(args.splice(0).join(','), 'disconnected: outer-test,disconnected: inner-test,disconnected: inner-test,disconnected: inner-test', 'inner elements of shadow roots get disconnected too');
+
+outer.remove();
+assert(args.length, 0, 'should not trigger disconnected again for shadow roots');
+
+outer = document.createElement('outer-test');
 customElements.define('inner-button', class extends HTMLButtonElement {
   static get observedAttributes() { return ['test']; }
   attributeChangedCallback(name, oldValue, newValue) {

--- a/test/interface/shadow-root.js
+++ b/test/interface/shadow-root.js
@@ -12,6 +12,8 @@ const shadowRoot = documentElement.attachShadow({mode: 'open'});
 
 assert(documentElement.shadowRoot, shadowRoot, 'yes shadowRoot');
 
+assert(documentElement.shadowRoot.host, documentElement, 'yes shadowRoot.host');
+
 try {
   documentElement.attachShadow({mode: 'open'});
   assert(true, false, 'double shadowRoot should not be possible');

--- a/types/esm/interface/shadow-root.d.ts
+++ b/types/esm/interface/shadow-root.d.ts
@@ -2,7 +2,8 @@
  * @implements globalThis.ShadowRoot
  */
 export class ShadowRoot extends NonElementParentNode implements globalThis.ShadowRoot {
-    constructor(ownerDocument: any);
+    constructor(host: any);
+    host: any;
     set innerHTML(arg: any);
     get innerHTML(): any;
 }

--- a/types/esm/shared/shadow-roots.d.ts
+++ b/types/esm/shared/shadow-roots.d.ts
@@ -1,0 +1,1 @@
+export const shadowRoots: WeakMap<object, any>;

--- a/worker.js
+++ b/worker.js
@@ -8525,6 +8525,8 @@ const setAdjacent = (prev, next) => {
     next[PREV] = prev;
 };
 
+const shadowRoots = new WeakMap;
+
 let reactive = false;
 
 const Classes = new WeakMap;
@@ -8557,7 +8559,9 @@ const triggerConnected = createTrigger('connectedCallback', true);
 const connectedCallback = element => {
   if (reactive) {
     triggerConnected(element);
-    let {[NEXT]: next, [END]: end} = element.shadowRoot || element;
+    if (shadowRoots.has(element))
+      element = shadowRoots.get(element).shadowRoot;
+    let {[NEXT]: next, [END]: end} = element;
     while (next !== end) {
       if (next.nodeType === ELEMENT_NODE)
         triggerConnected(next);
@@ -8570,7 +8574,9 @@ const triggerDisconnected = createTrigger('disconnectedCallback', false);
 const disconnectedCallback = element => {
   if (reactive) {
     triggerDisconnected(element);
-    let {[NEXT]: next, [END]: end} = element.shadowRoot || element;
+    if (shadowRoots.has(element))
+      element = shadowRoots.get(element).shadowRoot;
+    let {[NEXT]: next, [END]: end} = element;
     while (next !== end) {
       if (next.nodeType === ELEMENT_NODE)
         triggerDisconnected(next);
@@ -12449,7 +12455,6 @@ const isVoid = ({localName, ownerDocument}) => {
   return ownerDocument[MIME].voidElements.test(localName);
 };
 
-const shadowRoots = new WeakMap;
 // </utils>
 
 /**

--- a/worker.js
+++ b/worker.js
@@ -8557,7 +8557,7 @@ const triggerConnected = createTrigger('connectedCallback', true);
 const connectedCallback = element => {
   if (reactive) {
     triggerConnected(element);
-    let {[NEXT]: next, [END]: end} = element;
+    let {[NEXT]: next, [END]: end} = element.shadowRoot || element;
     while (next !== end) {
       if (next.nodeType === ELEMENT_NODE)
         triggerConnected(next);
@@ -8570,7 +8570,7 @@ const triggerDisconnected = createTrigger('disconnectedCallback', false);
 const disconnectedCallback = element => {
   if (reactive) {
     triggerDisconnected(element);
-    let {[NEXT]: next, [END]: end} = element;
+    let {[NEXT]: next, [END]: end} = element.shadowRoot || element;
     while (next !== end) {
       if (next.nodeType === ELEMENT_NODE)
         triggerDisconnected(next);
@@ -9456,7 +9456,7 @@ const isConnected = ({ownerDocument, parentNode}) => {
   while (parentNode) {
     if (parentNode === ownerDocument)
       return true;
-    parentNode = parentNode.parentNode;
+    parentNode = parentNode.parentNode || parentNode.host;
   }
   return false;
 };
@@ -12414,8 +12414,9 @@ class NamedNodeMap extends Array {
  * @implements globalThis.ShadowRoot
  */
 class ShadowRoot$1 extends NonElementParentNode {
-  constructor(ownerDocument) {
-    super(ownerDocument, '#shadow-root', DOCUMENT_FRAGMENT_NODE);
+  constructor(host) {
+    super(host.ownerDocument, '#shadow-root', DOCUMENT_FRAGMENT_NODE);
+    this.host = host;
   }
 
   get innerHTML() {
@@ -12679,7 +12680,7 @@ class Element$1 extends ParentNode {
       throw new Error('operation not supported');
     // TODO: shadowRoot should be likely a specialized class that extends DocumentFragment
     //       but until DSD is out, I am not sure I should spend time on this.
-    const shadowRoot = new ShadowRoot$1(this.ownerDocument);
+    const shadowRoot = new ShadowRoot$1(this);
     shadowRoot.append(...this.childNodes);
     shadowRoots.set(this, {
       mode: init.mode,


### PR DESCRIPTION
Thanks for this wonderful library!  This PR makes sure to fire `connectedCallback` and `disconnectedCallback` even for custom elements contained within shadow roots of other custom elements.  

When recursively firing `connectedCallback` and `disconnectedCallback` we need to traverse down through any shadow roots we find along the way.

And then when determining `isConnected` for a node within a shadow root, we need to traverse up through shadow root host elements to find our way to the owner document.  In order to facilitate this, we implement the [`host`](https://dom.spec.whatwg.org/#dom-shadowroot-host) property for shadow roots. 

