### PR TITLE
fix: `:scope` selector

### DIFF
--- a/cjs/mixin/parent-node.js
+++ b/cjs/mixin/parent-node.js
@@ -180,7 +180,7 @@ class ParentNode extends Node {
   }
 
   querySelector(selectors) {
-    const matches = prepareMatch(this, selectors);
+    const matches = prepareMatch(this, selectors, this);
     let {[NEXT]: next, [END]: end} = this;
     while (next !== end) {
       if (next.nodeType === ELEMENT_NODE && matches(next))
@@ -191,7 +191,7 @@ class ParentNode extends Node {
   }
 
   querySelectorAll(selectors) {
-    const matches = prepareMatch(this, selectors);
+    const matches = prepareMatch(this, selectors, this);
     const elements = new NodeList;
     let {[NEXT]: next, [END]: end} = this;
     while (next !== end) {

--- a/cjs/shared/matches.js
+++ b/cjs/shared/matches.js
@@ -101,6 +101,7 @@ const adapter = {
 const prepareMatch = (element, selectors) => {
   return CSSselect.compile(selectors, {
     xmlMode: !ignoreCase(element),
+    context: element,
     adapter
   });
 };
@@ -110,6 +111,7 @@ const matches = (element, selectors) => {
   return CSSselect.is(element, selectors, {
     strict: true,
     xmlMode: !ignoreCase(element),
+    context: element,
     adapter
   });
 };

--- a/cjs/shared/matches.js
+++ b/cjs/shared/matches.js
@@ -98,20 +98,20 @@ const adapter = {
   findOne
 };
 
-const prepareMatch = (element, selectors) => {
+const prepareMatch = (element, selectors, context) => {
   return CSSselect.compile(selectors, {
     xmlMode: !ignoreCase(element),
-    context: element,
+    context,
     adapter
   });
 };
 exports.prepareMatch = prepareMatch;
 
-const matches = (element, selectors) => {
+const matches = (element, selectors, context) => {
   return CSSselect.is(element, selectors, {
     strict: true,
     xmlMode: !ignoreCase(element),
-    context: element,
+    context,
     adapter
   });
 };

--- a/esm/mixin/parent-node.js
+++ b/esm/mixin/parent-node.js
@@ -179,7 +179,7 @@ export class ParentNode extends Node {
   }
 
   querySelector(selectors) {
-    const matches = prepareMatch(this, selectors);
+    const matches = prepareMatch(this, selectors, this);
     let {[NEXT]: next, [END]: end} = this;
     while (next !== end) {
       if (next.nodeType === ELEMENT_NODE && matches(next))
@@ -190,7 +190,7 @@ export class ParentNode extends Node {
   }
 
   querySelectorAll(selectors) {
-    const matches = prepareMatch(this, selectors);
+    const matches = prepareMatch(this, selectors, this);
     const elements = new NodeList;
     let {[NEXT]: next, [END]: end} = this;
     while (next !== end) {

--- a/esm/shared/matches.js
+++ b/esm/shared/matches.js
@@ -97,19 +97,19 @@ const adapter = {
   findOne
 };
 
-export const prepareMatch = (element, selectors) => {
+export const prepareMatch = (element, selector, context) => {
   return CSSselect.compile(selectors, {
     xmlMode: !ignoreCase(element),
-    context: element,
+    context,
     adapter
   });
 };
 
-export const matches = (element, selectors) => {
+export const matches = (element, selectors, context) => {
   return CSSselect.is(element, selectors, {
     strict: true,
     xmlMode: !ignoreCase(element),
-    context: element,
+    context,
     adapter
   });
 };

--- a/esm/shared/matches.js
+++ b/esm/shared/matches.js
@@ -100,6 +100,7 @@ const adapter = {
 export const prepareMatch = (element, selectors) => {
   return CSSselect.compile(selectors, {
     xmlMode: !ignoreCase(element),
+    context: element,
     adapter
   });
 };
@@ -108,6 +109,7 @@ export const matches = (element, selectors) => {
   return CSSselect.is(element, selectors, {
     strict: true,
     xmlMode: !ignoreCase(element),
+    context: element,
     adapter
   });
 };

--- a/types/esm/shared/matches.d.ts
+++ b/types/esm/shared/matches.d.ts
@@ -1,2 +1,2 @@
-export function prepareMatch(element: any, selectors: any): any;
-export function matches(element: any, selectors: any): any;
+export function prepareMatch(element: any, selectors: any, context?: any): any;
+export function matches(element: any, selectors: any, context?: any): any;

--- a/types/shared/matches.d.ts
+++ b/types/shared/matches.d.ts
@@ -1,2 +1,2 @@
-export function prepareMatch(element: any, selectors: any): any;
-export function matches(element: any, selectors: any): any;
+export function prepareMatch(element: any, selectors: any, context?: any): any;
+export function matches(element: any, selectors: any, context?: any): any;

--- a/worker.js
+++ b/worker.js
@@ -6410,17 +6410,19 @@ const adapter = {
   findOne
 };
 
-const prepareMatch = (element, selectors) => {
+const prepareMatch = (element, selectors, context) => {
   return compile(selectors, {
     xmlMode: !ignoreCase(element),
+    context,
     adapter
   });
 };
 
-const matches = (element, selectors) => {
+const matches = (element, selectors, context) => {
   return is(element, selectors, {
     strict: true,
     xmlMode: !ignoreCase(element),
+    context,
     adapter
   });
 };
@@ -6641,7 +6643,7 @@ class ParentNode extends Node$1 {
   }
 
   querySelector(selectors) {
-    const matches = prepareMatch(this, selectors);
+    const matches = prepareMatch(this, selectors, this);
     let {[NEXT]: next, [END]: end} = this;
     while (next !== end) {
       if (next.nodeType === ELEMENT_NODE && matches(next))
@@ -6652,7 +6654,7 @@ class ParentNode extends Node$1 {
   }
 
   querySelectorAll(selectors) {
-    const matches = prepareMatch(this, selectors);
+    const matches = prepareMatch(this, selectors, this);
     const elements = new NodeList;
     let {[NEXT]: next, [END]: end} = this;
     while (next !== end) {


### PR DESCRIPTION
Very simple fix to add the element as the context for css-select calls which fixes all issues related to using `:scope` selector.
Closes #75 