### PR TITLE
fix: scope selector in union

### DIFF
--- a/cjs/shared/matches.js
+++ b/cjs/shared/matches.js
@@ -2,7 +2,7 @@
 const CSSselect = require('css-select');
 
 const {ELEMENT_NODE, TEXT_NODE} = require('./constants.js');
-const {ignoreCase} = require('./utils.js');
+const {ignoreCase, usesScopePseudoClass} = require('./utils.js');
 
 const {isArray} = Array;
 
@@ -101,7 +101,7 @@ const adapter = {
 const prepareMatch = (element, selectors) => CSSselect.compile(
   selectors,
   {
-    context: selectors.includes(':scope') ? element : void 0,
+    context: usesScopePseudoClass(selectors) ? element : void 0,
     xmlMode: !ignoreCase(element),
     adapter
   }
@@ -113,7 +113,7 @@ const matches = (element, selectors) => CSSselect.is(
   selectors,
   {
     strict: true,
-    context: selectors.includes(':scope') ? element : void 0,
+    context: usesScopePseudoClass(selectors) ? element : void 0,
     xmlMode: !ignoreCase(element),
     adapter
   }

--- a/cjs/shared/utils.js
+++ b/cjs/shared/utils.js
@@ -11,6 +11,9 @@ exports.getEnd = getEnd;
 const ignoreCase = ({ownerDocument}) => ownerDocument[MIME].ignoreCase;
 exports.ignoreCase = ignoreCase;
 
+const usesScopePseudoClass = (selectors) => selectors.split(/,/g).some(selector => /^\s*:(scope)\b/.test(selector));
+exports.usesScopePseudoClass = usesScopePseudoClass;
+
 const knownAdjacent = (prev, next) => {
   prev[NEXT] = next;
   next[PREV] = prev;

--- a/esm/shared/matches.js
+++ b/esm/shared/matches.js
@@ -1,7 +1,7 @@
 import * as CSSselect from 'css-select';
 
 import {ELEMENT_NODE, TEXT_NODE} from './constants.js';
-import {ignoreCase} from './utils.js';
+import {ignoreCase, usesScopePseudoClass} from './utils.js';
 
 const {isArray} = Array;
 
@@ -100,7 +100,7 @@ const adapter = {
 export const prepareMatch = (element, selectors) => CSSselect.compile(
   selectors,
   {
-    context: selectors.includes(':scope') ? element : void 0,
+    context: usesScopePseudoClass(selectors) ? element : void 0,
     xmlMode: !ignoreCase(element),
     adapter
   }
@@ -111,7 +111,7 @@ export const matches = (element, selectors) => CSSselect.is(
   selectors,
   {
     strict: true,
-    context: selectors.includes(':scope') ? element : void 0,
+    context: usesScopePseudoClass(selectors) ? element : void 0,
     xmlMode: !ignoreCase(element),
     adapter
   }

--- a/esm/shared/utils.js
+++ b/esm/shared/utils.js
@@ -8,6 +8,8 @@ export const getEnd = node => node.nodeType === ELEMENT_NODE ? node[END] : node;
 
 export const ignoreCase = ({ownerDocument}) => ownerDocument[MIME].ignoreCase;
 
+export const usesScopePseudoClass = (selectors) => selectors.split(/,/g).some(selector => /^\s*:(scope)\b/.test(selector));
+
 export const knownAdjacent = (prev, next) => {
   prev[NEXT] = next;
   next[PREV] = prev;

--- a/test/interface/named-node-map.js
+++ b/test/interface/named-node-map.js
@@ -72,6 +72,9 @@ assert(node.toString(), '<div disabled class="b c">abc</div>', 'toggle');
 assert(node.firstChild.previousElementSibling, null, 'previousElementSibling attributes');
 assert(node.matches('[disabled]'), true, 'yes matches');
 assert(node.matches(':scope[disabled]'), true, ':scope matches');
+assert(node.matches('[none],:scope'), true, ':scope matches in union');
+assert(node.matches(':root>[disabled]'), true, ':root matches');
+// assert(node.matches('[none],:root'), true, ':root matches in union');  // fails
 node.toggleAttribute('disabled');
 assert(node.toString(), '<div class="b c">abc</div>', 'toggle');
 assert(document.getElementsByClassName('b')[0], node, 'getElementsByClassName');

--- a/test/interface/text.js
+++ b/test/interface/text.js
@@ -34,6 +34,8 @@ node.firstChild.firstChild.cloneNode(true);
 node.firstChild.firstChild.cloneNode();
 assert(node.firstChild.closest('p'), node.firstChild, 'closest(sameNode)');
 assert(node.firstChild.closest(':scope'), node.firstChild, 'closest(:scope)');
+assert(node.firstChild.closest('[none],:scope'), node.firstChild, 'closest([none],:scope)');
+assert(node.firstChild.closest(':root'), document.documentElement, 'closest(:root)');
 assert(node.firstChild.closest('nope'), null, 'closest(nope)');
 assert(!node.firstChild.firstChild.isEqualNode(text), true, 'isEqualNode');
 assert(node.firstChild.firstChild.isEqualNode(node.firstChild.firstChild.cloneNode(true)), true, 'isEqualNode');

--- a/worker.js
+++ b/worker.js
@@ -6410,10 +6410,13 @@ const adapter = {
   findOne
 };
 
+// copied from '{cjs|esm}/shared/utils
+const usesScopePseudoClass = (selectors) => selectors.split(/,/g).some(selector => /^\s*:(scope)\b/.test(selector));
+
 const prepareMatch = (element, selectors) => compile(
   selectors,
   {
-    context: selectors.includes(':scope') ? element : void 0,
+    context: usesScopePseudoClass(selectors) ? element : void 0,
     xmlMode: !ignoreCase(element),
     adapter
   }
@@ -6424,7 +6427,7 @@ const matches = (element, selectors) => is(
   selectors,
   {
     strict: true,
-    context: selectors.includes(':scope') ? element : void 0,
+    context: usesScopePseudoClass(selectors) ? element : void 0,
     xmlMode: !ignoreCase(element),
     adapter
   }


### PR DESCRIPTION
Adds broader support for `:scope`, specifically in union selector queries.

Still not perfect as someone could potentially have a query like `div[data-attr="fake,:scope>query"]` but that's very obscure.

Something else learned during integration is that the current `:root` selector is not perfect as it fails union queries (see commented out test case added in commit).