### PR TITLE
Add "types" field to "exports"

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
   "type": "module",
   "exports": {
     ".": {
+      "types": "./types/esm/index.d.ts",
       "import": "./esm/index.js",
       "default": "./cjs/index.js"
     },


### PR DESCRIPTION
Add "types" field to "exports" object in package.json in order to make types available to projects using TypeScript and ESM (NodeNext module resolution).