### PR TITLE
fix attribute clone missing ownerElement

### DIFF
--- a/esm/interface/element.js
+++ b/esm/interface/element.js
@@ -138,7 +138,7 @@ export class Element extends ParentNode {
 
 
   // <contentRelated>
-  get innerText() { 
+  get innerText() {
     const text = [];
     let {[NEXT]: next, [END]: end} = this;
     while (next !== end) {
@@ -396,7 +396,12 @@ export class Element extends ParentNode {
           parentNode = node;
           break;
         }
-        case ATTRIBUTE_NODE:
+        case ATTRIBUTE_NODE: {
+          const attr = next.cloneNode(deep);
+          attr.ownerElement = next.ownerElement;
+          addNext(attr);
+          break;
+        }
         case TEXT_NODE:
         case COMMENT_NODE:
           addNext(next.cloneNode(deep));

--- a/test/interface/clone-node.js
+++ b/test/interface/clone-node.js
@@ -1,0 +1,13 @@
+const assert = require('../assert.js').for('CloneNode');
+
+const {parseHTML} = global[Symbol.for('linkedom')];
+
+const {document} = parseHTML('<html><div></div></html>');
+
+let div = document.querySelector('div');
+
+const clone = div.cloneNode(true);
+clone.setAttribute('class', 'active');
+
+assert(clone.toString(), '<div class="active"></div>');
+assert(clone.attributes[0].ownerElement, clone);


### PR DESCRIPTION
This fixes missing ownerElement when attribute is cloned. See included example.

```js
import { parseHTML } from './esm/index.js';

const w = parseHTML(`<html><body>

<select value="{{fruit=$value}}" each="{{[fruits,'f']}}"><option value="{{f}}">{{f}}</option></select>

</body></html>`);

// w.document.toString();
// console.log(w.document.body.innerHTML);

const notClone = w.document.body.firstElementChild.firstElementChild;
const notCloneAt = notClone.attributes[0];
console.log(notCloneAt.name, notCloneAt.value, notCloneAt.ownerElement.outerHTML);

const clone = w.document.body.firstElementChild.firstElementChild.cloneNode(true);
const cloneAt = clone.attributes[0];
console.log(cloneAt.name, cloneAt.value, cloneAt.ownerElement.outerHTML); // without a fix ownerElement is not assigned
```