### PR TITLE
Added `iframe` attributes

### DIFF
--- a/cjs/html/i-frame-element.js
+++ b/cjs/html/i-frame-element.js
@@ -1,6 +1,6 @@
 'use strict';
 const {registerHTMLClass} = require('../shared/register-html-class.js');
-const {stringAttribute} = require('../shared/attributes.js');
+const {booleanAttribute, stringAttribute} = require('../shared/attributes.js');
 
 const {HTMLElement} = require('./element.js');
 
@@ -17,6 +17,24 @@ class HTMLIFrameElement extends HTMLElement {
   /* c8 ignore start */
   get src() { return stringAttribute.get(this, 'src'); }
   set src(value) { stringAttribute.set(this, 'src', value); }
+
+  get srcdoc() { return stringAttribute.get(this, "srcdoc"); }
+  set srcdoc(value) { stringAttribute.set(this, "srcdoc", value); }
+
+  get name() { return stringAttribute.get(this, "name"); }
+  set name(value) { stringAttribute.set(this, "name", value); }
+
+  get allow() { return stringAttribute.get(this, "allow"); }
+  set allow(value) { stringAttribute.set(this, "allow", value); }
+
+  get allowFullscreen() { return booleanAttribute.get(this, "allowfullscreen"); }
+  set allowFullscreen(value) { booleanAttribute.set(this, "allowfullscreen", value); }
+  
+  get referrerPolicy() { return stringAttribute.get(this, "referrerpolicy"); }
+  set referrerPolicy(value) { stringAttribute.set(this, "referrerpolicy", value); }
+  
+  get loading() { return stringAttribute.get(this, "loading"); }
+  set loading(value) { stringAttribute.set(this, "loading", value); }
   /* c8 ignore stop */
 }
 

--- a/esm/html/i-frame-element.js
+++ b/esm/html/i-frame-element.js
@@ -1,5 +1,5 @@
 import {registerHTMLClass} from '../shared/register-html-class.js';
-import {stringAttribute} from '../shared/attributes.js';
+import {booleanAttribute, stringAttribute} from '../shared/attributes.js';
 
 import {HTMLElement} from './element.js';
 
@@ -16,6 +16,24 @@ class HTMLIFrameElement extends HTMLElement {
   /* c8 ignore start */
   get src() { return stringAttribute.get(this, 'src'); }
   set src(value) { stringAttribute.set(this, 'src', value); }
+
+  get srcdoc() { return stringAttribute.get(this, "srcdoc"); }
+  set srcdoc(value) { stringAttribute.set(this, "srcdoc", value); }
+
+  get name() { return stringAttribute.get(this, "name"); }
+  set name(value) { stringAttribute.set(this, "name", value); }
+
+  get allow() { return stringAttribute.get(this, "allow"); }
+  set allow(value) { stringAttribute.set(this, "allow", value); }
+
+  get allowFullscreen() { return booleanAttribute.get(this, "allowfullscreen"); }
+  set allowFullscreen(value) { booleanAttribute.set(this, "allowfullscreen", value); }
+  
+  get referrerPolicy() { return stringAttribute.get(this, "referrerpolicy"); }
+  set referrerPolicy(value) { stringAttribute.set(this, "referrerpolicy", value); }
+  
+  get loading() { return stringAttribute.get(this, "loading"); }
+  set loading(value) { stringAttribute.set(this, "loading", value); }
   /* c8 ignore stop */
 }
 

--- a/test/html/i-frame-element.js
+++ b/test/html/i-frame-element.js
@@ -13,10 +13,10 @@ assert(iframe.src, './test.html', 'Issue #82 - <iframe>.src');
   const { document } = parseHTML("<html><body><iframe></iframe></body></html>");
   const iframe = document.body.querySelector("iframe");
 
-  iframe.srcdoc = `<html><span>Test</span></html>`;
+  iframe.srcdoc = `<html><span style="color: red">Test</span></html>`;
   assert(
     document.body.innerHTML,
-    `<iframe srcdoc="<html><span>Test</span></html>"></iframe>`
+    `<iframe srcdoc="<html><span style=&quot;color: red&quot;>Test</span></html>"></iframe>`
   );
 }
 

--- a/test/html/i-frame-element.js
+++ b/test/html/i-frame-element.js
@@ -7,3 +7,55 @@ const {document} = parseHTML('<html><iframe src="./test.html"></html>');
 const {firstElementChild: iframe} = document.documentElement;
 
 assert(iframe.src, './test.html', 'Issue #82 - <iframe>.src');
+
+
+{
+  const { document } = parseHTML("<html><body><iframe></iframe></body></html>");
+  const iframe = document.body.querySelector("iframe");
+
+  iframe.srcdoc = `<html><span>Test</span></html>`;
+  assert(
+    document.body.innerHTML,
+    `<iframe srcdoc="<html><span>Test</span></html>"></iframe>`
+  );
+}
+
+{
+  const { document } = parseHTML("<html><body><iframe></iframe></body></html>");
+  const iframe = document.body.querySelector("iframe");
+
+  iframe.allow = "geolocation";
+  iframe.name = "iframe-name";
+  iframe.referrerPolicy = "no-referrer";
+  iframe.loading = "lazy";
+  assert(
+    document.body.innerHTML,
+    `<iframe loading="lazy" referrerpolicy="no-referrer" name="iframe-name" allow="geolocation"></iframe>`
+  );
+}
+
+{
+  const { document } = parseHTML(
+    "<html><body><iframe allowfullscreen></iframe></body></html>"
+  );
+  const iframe = document.body.querySelector("iframe");
+  assert(iframe.allowFullscreen, true);
+  iframe.allowFullscreen = false;
+  assert(
+    document.body.innerHTML,
+    `<iframe></iframe>`
+  );
+}
+
+{
+  const { document } = parseHTML(
+   `<html><body><iframe loading="lazy" referrerpolicy="no-referrer" name="iframe-name" allow="geolocation"></iframe></body></html>`
+  ); 
+
+  const iframe = document.body.querySelector("iframe");
+  assert(iframe.allowFullscreen, false);
+  assert(iframe.loading, 'lazy');
+  assert(iframe.referrerPolicy, "no-referrer");
+  assert(iframe.name, "iframe-name");
+  assert(iframe.allow, "geolocation");
+}

--- a/types/commonjs/canvas-shim.d.cts
+++ b/types/commonjs/canvas-shim.d.cts
@@ -1,0 +1,9 @@
+declare class Canvas {
+    constructor(width: any, height: any);
+    width: any;
+    height: any;
+    getContext(): any;
+    toDataURL(): string;
+}
+export function createCanvas(width: any, height: any): Canvas;
+export {};

--- a/types/esm/html/i-frame-element.d.ts
+++ b/types/esm/html/i-frame-element.d.ts
@@ -4,5 +4,17 @@
 export class HTMLIFrameElement extends HTMLElement implements globalThis.HTMLIFrameElement {
     set src(arg: any);
     get src(): any;
+    set srcdoc(arg: any);
+    get srcdoc(): any;
+    set name(arg: any);
+    get name(): any;
+    set allow(arg: any);
+    get allow(): any;
+    set allowFullscreen(arg: any);
+    get allowFullscreen(): any;
+    set referrerPolicy(arg: any);
+    get referrerPolicy(): any;
+    set loading(arg: any);
+    get loading(): any;
 }
 import { HTMLElement } from "./element.js";

--- a/worker.js
+++ b/worker.js
@@ -8243,6 +8243,24 @@ class HTMLIFrameElement extends HTMLElement {
   /* c8 ignore start */
   get src() { return stringAttribute.get(this, 'src'); }
   set src(value) { stringAttribute.set(this, 'src', value); }
+
+  get srcdoc() { return stringAttribute.get(this, "srcdoc"); }
+  set srcdoc(value) { stringAttribute.set(this, "srcdoc", value); }
+
+  get name() { return stringAttribute.get(this, "name"); }
+  set name(value) { stringAttribute.set(this, "name", value); }
+
+  get allow() { return stringAttribute.get(this, "allow"); }
+  set allow(value) { stringAttribute.set(this, "allow", value); }
+
+  get allowFullscreen() { return booleanAttribute.get(this, "allowfullscreen"); }
+  set allowFullscreen(value) { booleanAttribute.set(this, "allowfullscreen", value); }
+  
+  get referrerPolicy() { return stringAttribute.get(this, "referrerpolicy"); }
+  set referrerPolicy(value) { stringAttribute.set(this, "referrerpolicy", value); }
+  
+  get loading() { return stringAttribute.get(this, "loading"); }
+  set loading(value) { stringAttribute.set(this, "loading", value); }
   /* c8 ignore stop */
 }
 


### PR DESCRIPTION
Added following `iframe` attributes:

- [srcdoc](https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-iframe-srcdoc) — A document to render in the iframe
- [name](https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-iframe-name) — Name of nested navigable
- [allow](https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-iframe-allow) — Permissions policy to be applied to the iframe's contents
- [allowFullscreen](https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-iframe-allowfullscreen) — Whether to allow the iframe's contents to use `requestFullscreen()`
- [referrerPolicy](https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-iframe-referrerpolicy) — Referrer policy for fetches initiated by the element
- [loading](https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-iframe-loading) — Used when determining loading deferral