### PR TITLE
Ensuring /cached and /worker entrypoints are recognized by TypeScript

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,16 @@
     "./package.json": "./package.json",
     "./worker": "./worker.js"
   },
+  "typesVersions": {
+    "*": {
+      "cached": [
+        "./types/esm/index.d.ts"
+      ],
+      "worker": [
+        "./types/esm/index.d.ts"
+      ]
+    }
+  },
   "dependencies": {
     "css-select": "^5.1.0",
     "cssom": "^0.5.0",


### PR DESCRIPTION
I remembered that I stumbled on this same issue with [Voby](https://github.com/vobyjs/voby/blob/d9712d8a9dc770891522591b2548c756c7ca8acd/package.json#L24-L33), and after some major headaches the solution was that there just was no reasonable way to provide types for submodules, the only way to do it is by abusing the `"typesVersions"` property. This is maybe something that should get addressed in TS v5.

In any case this PR closes #194.

I'm reusing the types for the default export for the worker export, since I don't see more specific ones for that, if /worker exports a different interface then different types should be generated I guess.