### PR TITLE
chore(deps): bump uhyphen from 0.1.0 to 0.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "cssom": "^0.5.0",
         "html-escaper": "^3.0.3",
         "htmlparser2": "^8.0.1",
-        "uhyphen": "^0.1.0"
+        "uhyphen": "^0.2.0"
       },
       "devDependencies": {
         "@rollup/plugin-commonjs": "^22.0.0",
@@ -1645,9 +1645,9 @@
       }
     },
     "node_modules/uhyphen": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/uhyphen/-/uhyphen-0.1.0.tgz",
-      "integrity": "sha512-o0QVGuFg24FK765Qdd5kk0zU/U4dEsCtN/GSiwNI9i8xsSVtjIAOdTaVhLwZ1nrbWxFVMxNDDl+9fednsOMsBw=="
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/uhyphen/-/uhyphen-0.2.0.tgz",
+      "integrity": "sha512-qz3o9CHXmJJPGBdqzab7qAYuW8kQGKNEuoHFYrBwV6hWIMcpAmxDLXojcHfFr9US1Pe6zUswEIJIbLI610fuqA=="
     },
     "node_modules/uri-js": {
       "version": "4.4.1",
@@ -2981,9 +2981,9 @@
       "dev": true
     },
     "uhyphen": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/uhyphen/-/uhyphen-0.1.0.tgz",
-      "integrity": "sha512-o0QVGuFg24FK765Qdd5kk0zU/U4dEsCtN/GSiwNI9i8xsSVtjIAOdTaVhLwZ1nrbWxFVMxNDDl+9fednsOMsBw=="
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/uhyphen/-/uhyphen-0.2.0.tgz",
+      "integrity": "sha512-qz3o9CHXmJJPGBdqzab7qAYuW8kQGKNEuoHFYrBwV6hWIMcpAmxDLXojcHfFr9US1Pe6zUswEIJIbLI610fuqA=="
     },
     "uri-js": {
       "version": "4.4.1",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "cssom": "^0.5.0",
     "html-escaper": "^3.0.3",
     "htmlparser2": "^8.0.1",
-    "uhyphen": "^0.1.0"
+    "uhyphen": "^0.2.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Use version `0.2.0` of [uhyphen](https://github.com/WebReflection/uhyphen) to get this fix: https://github.com/WebReflection/uhyphen/commit/b0eb24f77fdd18a22a3827b1e678da4a7005fa55

I [wrote](https://github.com/WebReflection/uhyphen/issues/1#issuecomment-1315777933) that _I tested `mp4HdSource` with LinkeDOM 0.14.20: this bug is fixed._ But I think I tested wrong because I still have the problem in LinkeDOM.