### PR TITLE
fix for attachShadow no longer adding childNodes to shadowRoot

### DIFF
--- a/cjs/interface/element.js
+++ b/cjs/interface/element.js
@@ -316,7 +316,6 @@ class Element extends ParentNode {
     // TODO: shadowRoot should be likely a specialized class that extends DocumentFragment
     //       but until DSD is out, I am not sure I should spend time on this.
     const shadowRoot = new ShadowRoot(this);
-    shadowRoot.append(...this.childNodes);
     shadowRoots.set(this, {
       mode: init.mode,
       shadowRoot

--- a/esm/interface/element.js
+++ b/esm/interface/element.js
@@ -315,7 +315,7 @@ export class Element extends ParentNode {
   attachShadow(init) {
     if (shadowRoots.has(this))
       throw new Error('operation not supported');
-      // TODO: shadowRoot should be likely a specialized class that extends DocumentFragment
+    // TODO: shadowRoot should be likely a specialized class that extends DocumentFragment
     //       but until DSD is out, I am not sure I should spend time on this.
     const shadowRoot = new ShadowRoot(this);
     shadowRoots.set(this, {

--- a/esm/interface/element.js
+++ b/esm/interface/element.js
@@ -315,10 +315,9 @@ export class Element extends ParentNode {
   attachShadow(init) {
     if (shadowRoots.has(this))
       throw new Error('operation not supported');
-    // TODO: shadowRoot should be likely a specialized class that extends DocumentFragment
+      // TODO: shadowRoot should be likely a specialized class that extends DocumentFragment
     //       but until DSD is out, I am not sure I should spend time on this.
     const shadowRoot = new ShadowRoot(this);
-    shadowRoot.append(...this.childNodes);
     shadowRoots.set(this, {
       mode: init.mode,
       shadowRoot

--- a/worker.js
+++ b/worker.js
@@ -7441,7 +7441,6 @@ let Element$1 = class Element extends ParentNode {
     // TODO: shadowRoot should be likely a specialized class that extends DocumentFragment
     //       but until DSD is out, I am not sure I should spend time on this.
     const shadowRoot = new ShadowRoot$1(this);
-    shadowRoot.append(...this.childNodes);
     shadowRoots.set(this, {
       mode: init.mode,
       shadowRoot


### PR DESCRIPTION
fix for #178: no longer adds the childNodes of the element to its shadowRoot when attaching a new shadowRoot