### PR TITLE
fix: getRootNode() bug

### DIFF
--- a/cjs/interface/node.js
+++ b/cjs/interface/node.js
@@ -188,11 +188,16 @@ class Node extends EventTarget {
     return this.parentNode;
   }
 
+  /**
+   * Calling it on an element inside a standard web page will return an HTMLDocument object representing the entire page (or <iframe>).
+   * Calling it on an element inside a shadow DOM will return the associated ShadowRoot.
+   * @return {ShadowRoot | HTMLDocument}
+   */
   getRootNode() {
     let root = this;
     while (root.parentNode)
       root = root.parentNode;
-    return root.nodeType === DOCUMENT_NODE ? root.documentElement : root;
+    return root;
   }
 }
 exports.Node = Node

--- a/esm/interface/node.js
+++ b/esm/interface/node.js
@@ -187,10 +187,15 @@ export class Node extends EventTarget {
     return this.parentNode;
   }
 
+  /**
+   * Calling it on an element inside a standard web page will return an HTMLDocument object representing the entire page (or <iframe>).
+   * Calling it on an element inside a shadow DOM will return the associated ShadowRoot.
+   * @return {ShadowRoot | HTMLDocument}
+   */
   getRootNode() {
     let root = this;
     while (root.parentNode)
       root = root.parentNode;
-    return root.nodeType === DOCUMENT_NODE ? root.documentElement : root;
+    return root;
   }
 }

--- a/test/interface/text.js
+++ b/test/interface/text.js
@@ -20,7 +20,7 @@ assert(text.isConnected, false, '!isConnected');
 assert(text.parentElement, null, '!parentElement');
 assert(node.contains(text), false, '!contains');
 node.firstChild.appendChild(text);
-assert(text.getRootNode(), document.documentElement, 'getRootNode as html');
+assert(text.getRootNode(), document, 'getRootNode as document');
 assert(node.contains(text), true, 'contains');
 assert(text.isConnected, true, 'isConnected');
 assert(text.parentElement, node.firstChild, 'parentElement');

--- a/types/esm/interface/image.d.ts
+++ b/types/esm/interface/image.d.ts
@@ -184,7 +184,7 @@ export function ImageClass(ownerDocument: any): {
         compareDocumentPosition(target: any): number;
         isEqualNode(node: any): boolean;
         _getParent(): any;
-        getRootNode(): any;
+        getRootNode(): ShadowRoot | HTMLDocument;
         [PREV]: any;
         addEventListener(type: any, listener: any, options: any): void;
         removeEventListener(type: any, listener: any): void;

--- a/types/esm/interface/node.d.ts
+++ b/types/esm/interface/node.d.ts
@@ -69,7 +69,12 @@ export class Node extends EventTarget implements globalThis.Node {
     isSameNode(node: any): boolean;
     compareDocumentPosition(target: any): number;
     isEqualNode(node: any): boolean;
-    getRootNode(): any;
+    /**
+     * Calling it on an element inside a standard web page will return an HTMLDocument object representing the entire page (or <iframe>).
+     * Calling it on an element inside a shadow DOM will return the associated ShadowRoot.
+     * @return {ShadowRoot | HTMLDocument}
+     */
+    getRootNode(): ShadowRoot | HTMLDocument;
     [NEXT]: any;
     [PREV]: any;
 }

--- a/types/esm/shared/node.d.ts
+++ b/types/esm/shared/node.d.ts
@@ -6,7 +6,7 @@ export function parentElement({ parentNode }: {
     parentNode: any;
 }): any;
 export function previousSibling({ [PREV]: prev }: {
-    "__@PREV@22226": any;
+    "__@PREV@22229": any;
 }): any;
 export function nextSibling(node: any): any;
 import { PREV } from "./symbols.js";

--- a/worker.js
+++ b/worker.js
@@ -4405,11 +4405,16 @@ let Node$1 = class Node extends DOMEventTarget {
     return this.parentNode;
   }
 
+  /**
+   * Calling it on an element inside a standard web page will return an HTMLDocument object representing the entire page (or <iframe>).
+   * Calling it on an element inside a shadow DOM will return the associated ShadowRoot.
+   * @return {ShadowRoot | HTMLDocument}
+   */
   getRootNode() {
     let root = this;
     while (root.parentNode)
       root = root.parentNode;
-    return root.nodeType === DOCUMENT_NODE ? root.documentElement : root;
+    return root;
   }
 };
 


### PR DESCRIPTION
the `<html>` element is [HTMLHtmlElement](https://developer.mozilla.org/en-US/docs/Web/API/HTMLHtmlElement)

`getRootNode()` returns 

An object inheriting from Node. This will differ in exact form depending on where you called getRootNode(); for example:

- Calling it on an element inside a standard web page will return an HTMLDocument object representing the entire page (or <iframe>).
- Calling it on an element inside a shadow DOM will return the associated ShadowRoot.

---

I ran in to this bug when calling getElementById on the root node but the method didn't exist with Linkedom.
Code here https://github.com/muxinc/media-chrome/blob/main/src/js/media-theme-element.js#L177-L178
