### PR TITLE
Escape NBSP to xml compatible entity

### DIFF
--- a/cjs/shared/text-escaper.js
+++ b/cjs/shared/text-escaper.js
@@ -5,7 +5,7 @@ const {replace} = '';
 const ca = /[<>&\xA0]/g;
 
 const esca = {
-  '\xA0': '&nbsp;',
+  '\xA0': '&#160;',
   '&': '&amp;',
   '<': '&lt;',
   '>': '&gt;'

--- a/esm/shared/text-escaper.js
+++ b/esm/shared/text-escaper.js
@@ -4,7 +4,7 @@ const {replace} = '';
 const ca = /[<>&\xA0]/g;
 
 const esca = {
-  '\xA0': '&nbsp;',
+  '\xA0': '&#160;',
   '&': '&amp;',
   '<': '&lt;',
   '>': '&gt;'

--- a/test/shared/text-escaper.js
+++ b/test/shared/text-escaper.js
@@ -1,4 +1,4 @@
-const BODY = '<body>Foo&nbsp;&quot;&nbsp;&quot;&nbsp;Bar</body>';
+const BODY = '<body>Foo&#160;&quot;&#160;&quot;&#160;Bar</body>';
 const REBODY = BODY.replace(/&quot;/g, '"');
 const HTML = `<html id="html" class="live">${BODY}</html>`;
 const REHTML = `<html id="html" class="live">${REBODY}</html>`;

--- a/worker.js
+++ b/worker.js
@@ -6356,7 +6356,7 @@ const {replace} = '';
 const ca = /[<>&\xA0]/g;
 
 const esca = {
-  '\xA0': '&nbsp;',
+  '\xA0': '&#160;',
   '&': '&amp;',
   '<': '&lt;',
   '>': '&gt;'


### PR DESCRIPTION
  Fix issue #205 
 
-  `&nbsp;` is the character entity reference (meant to be easily parseable by humans).
-  `&#160;` is the numeric entity reference (meant to be easily parseable by machines).

They are the same except for the fact that the latter does not need another lookup table to find its actual value, which make it compatible with XML without breaking HTML. Source off truth [offical W3C documents](https://www.w3.org/TR/html4/charset.html#h-5.3).