### PR TITLE
chore: set types on /cached export too

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
       "default": "./cjs/index.js"
     },
     "./cached": {
+      "types": "./types/esm/index.d.ts",
       "import": "./esm/cached.js",
       "default": "./cjs/cached.js"
     },


### PR DESCRIPTION
This is needed for projects using Node16/NodeNext and the `/cached` import, as otherwise it will throw an error that the import path doesn't exist