### PR TITLE
Add deep argument to the type of cloneNode()

### DIFF
--- a/types/esm/interface/node.d.ts
+++ b/types/esm/interface/node.d.ts
@@ -37,7 +37,7 @@ export class Node extends EventTarget implements globalThis.Node {
     set textContent(arg: any);
     get textContent(): any;
     normalize(): void;
-    cloneNode(): any;
+    cloneNode(deep?: boolean): any;
     contains(): boolean;
     /**
      * Inserts a node before a reference node as a child of this parent node.

--- a/types/interface/node.d.ts
+++ b/types/interface/node.d.ts
@@ -36,7 +36,7 @@ export class Node extends EventTarget implements globalThis.Node {
     set textContent(arg: any);
     get textContent(): any;
     normalize(): void;
-    cloneNode(): any;
+    cloneNode(deep?: boolean): any;
     contains(): boolean;
     /**
      * Inserts a node before a reference node as a child of this parent node.


### PR DESCRIPTION
`Node`'s `cloneNode()` should take the `deep` argument in type definition. Otherwise, other derived classes like `Element` also cannot take that parameter in TS.