### PR TITLE
types: parseHTML accepts a string

### DIFF
--- a/types/esm/index.d.ts
+++ b/types/esm/index.d.ts
@@ -8,6 +8,9 @@ export { EventTarget } from "./interface/event-target.js";
 export { InputEvent } from "./interface/input-event.js";
 export { NodeList } from "./interface/node-list.js";
 export { NodeFilter } from "./interface/node-filter.js";
-export function parseHTML(html: any, globals?: any): Window & typeof globalThis;
-import { DOMParser } from './dom/parser.js';
+export function parseHTML(
+  html: string,
+  globals?: any
+): Window & typeof globalThis;
+import { DOMParser } from "./dom/parser.js";
 export { parseJSON, toJSON } from "./shared/parse-json.js";

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -7,6 +7,6 @@ export { Event } from "./interface/event.js";
 export { EventTarget } from "./interface/event-target.js";
 export { InputEvent } from "./interface/input-event.js";
 export { NodeList } from "./interface/node-list.js";
-export function parseHTML(html: any): Window & typeof globalThis;
+export function parseHTML(html: string): Window & typeof globalThis;
 import { DOMParser } from "./dom/parser.js";
 export { parseJSON, toJSON } from "./shared/parse-json.js";


### PR DESCRIPTION
Hello,

I was trying to fix the following typescript issue:

<img width="710" alt="image" src="https://github.com/WebReflection/linkedom/assets/1730702/72fbb34e-ca3c-4f1c-8356-538ab9afe79a">

(`map` doesn't exist on the dom, but is valid with linkedom)

As a baby first step, I changed the input type of `parseHTML` from `any` to `string`.

Are you open to further refinement to remove the typing error when using `.map()` in the above example?