### PR TITLE
Fixed: inspecting document.title deleted it as a side-effect (when cached)

### DIFF
--- a/cjs/html/document.js
+++ b/cjs/html/document.js
@@ -78,12 +78,12 @@ class HTMLDocument extends Document {
    */
   get title() {
     const {head} = this;
-    return head.getElementsByTagName('title')[0]?.textContent || '';
+    return head.getElementsByTagName('title').at(0)?.textContent || '';
   }
 
   set title(textContent) {
     const {head} = this;
-    let title = head.getElementsByTagName('title')[0];
+    let title = head.getElementsByTagName('title').at(0);
     if (title)
       title.textContent = textContent;
     else {

--- a/cjs/html/document.js
+++ b/cjs/html/document.js
@@ -78,8 +78,7 @@ class HTMLDocument extends Document {
    */
   get title() {
     const {head} = this;
-    let title = head.getElementsByTagName('title')[0];
-    return title ? title.textContent : '';
+    return head.getElementsByTagName('title')[0]?.textContent || '';
   }
 
   set title(textContent) {

--- a/cjs/html/document.js
+++ b/cjs/html/document.js
@@ -78,13 +78,13 @@ class HTMLDocument extends Document {
    */
   get title() {
     const {head} = this;
-    let title = head.getElementsByTagName('title').shift();
+    let title = head.getElementsByTagName('title')[0];
     return title ? title.textContent : '';
   }
 
   set title(textContent) {
     const {head} = this;
-    let title = head.getElementsByTagName('title').shift();
+    let title = head.getElementsByTagName('title')[0];
     if (title)
       title.textContent = textContent;
     else {

--- a/esm/html/document.js
+++ b/esm/html/document.js
@@ -77,13 +77,13 @@ export class HTMLDocument extends Document {
    */
   get title() {
     const {head} = this;
-    let title = head.getElementsByTagName('title').shift();
+    let title = head.getElementsByTagName('title')[0];
     return title ? title.textContent : '';
   }
 
   set title(textContent) {
     const {head} = this;
-    let title = head.getElementsByTagName('title').shift();
+    let title = head.getElementsByTagName('title')[0];
     if (title)
       title.textContent = textContent;
     else {

--- a/esm/html/document.js
+++ b/esm/html/document.js
@@ -77,8 +77,7 @@ export class HTMLDocument extends Document {
    */
   get title() {
     const {head} = this;
-    let title = head.getElementsByTagName('title')[0];
-    return title ? title.textContent : '';
+    return head.getElementsByTagName('title')[0]?.textContent || '';
   }
 
   set title(textContent) {

--- a/esm/html/document.js
+++ b/esm/html/document.js
@@ -77,12 +77,12 @@ export class HTMLDocument extends Document {
    */
   get title() {
     const {head} = this;
-    return head.getElementsByTagName('title')[0]?.textContent || '';
+    return head.getElementsByTagName('title').at(0)?.textContent || '';
   }
 
   set title(textContent) {
     const {head} = this;
-    let title = head.getElementsByTagName('title')[0];
+    let title = head.getElementsByTagName('title').at(0);
     if (title)
       title.textContent = textContent;
     else {

--- a/test/html/document.js
+++ b/test/html/document.js
@@ -41,6 +41,9 @@ assert(document.title, '"hello"', 'title not escaped');
 assert(document.toString(), '<!DOCTYPE html><html><head><title>"hello"</title></head></html>');
 assert(document.body.tagName, 'BODY');
 
+document.title = 'I';
+assert(document.title + document.title + document.title, 'III', 'side-effects detected when inspecting the title');
+
 document.title = '&';
 assert(document.toString(), '<!DOCTYPE html><html><head><title>&</title></head><body></body></html>');
 

--- a/worker.js
+++ b/worker.js
@@ -12322,8 +12322,7 @@ class HTMLDocument extends Document$1 {
    */
   get title() {
     const {head} = this;
-    let title = head.getElementsByTagName('title')[0];
-    return title ? title.textContent : '';
+    return head.getElementsByTagName('title')[0]?.textContent || '';
   }
 
   set title(textContent) {

--- a/worker.js
+++ b/worker.js
@@ -12322,12 +12322,12 @@ class HTMLDocument extends Document$1 {
    */
   get title() {
     const {head} = this;
-    return head.getElementsByTagName('title')[0]?.textContent || '';
+    return head.getElementsByTagName('title').at(0)?.textContent || '';
   }
 
   set title(textContent) {
     const {head} = this;
-    let title = head.getElementsByTagName('title')[0];
+    let title = head.getElementsByTagName('title').at(0);
     if (title)
       title.textContent = textContent;
     else {

--- a/worker.js
+++ b/worker.js
@@ -12322,13 +12322,13 @@ class HTMLDocument extends Document$1 {
    */
   get title() {
     const {head} = this;
-    let title = head.getElementsByTagName('title').shift();
+    let title = head.getElementsByTagName('title')[0];
     return title ? title.textContent : '';
   }
 
   set title(textContent) {
     const {head} = this;
-    let title = head.getElementsByTagName('title').shift();
+    let title = head.getElementsByTagName('title')[0];
     if (title)
       title.textContent = textContent;
     else {


### PR DESCRIPTION
Minimal reproducible example with linkedom 0.16.10:

```
import { parseHTML } from 'linkedom/cached';

const html = '<!DOCTYPE html><html><head><title>Test</title></head><body></body></html>';
const { document } = parseHTML(html);
console.log('Title:', document.title); // Title: Test
console.log('Title:', document.title); // Title:          <-- missing (title removed as a side-effect)
```