### PR TITLE
fix: no types exports for `./worker` submodule

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,10 @@
       "default": "./cjs/cached.js"
     },
     "./package.json": "./package.json",
-    "./worker": "./worker.js"
+    "./worker": {
+      "types": "./types/esm/index.d.ts",
+      "import": "./worker.js"
+    }
   },
   "typesVersions": {
     "*": {


### PR DESCRIPTION
This PR fixes #271 