### PR TITLE
fix: prevent losing `rel` attr on anchor element

### DIFF
--- a/esm/html/anchor-element.js
+++ b/esm/html/anchor-element.js
@@ -25,6 +25,9 @@ class HTMLAnchorElement extends HTMLElement {
 
   get type() { return stringAttribute.get(this, 'type'); }
   set type(value) { stringAttribute.set(this, 'type', value); }
+
+  get rel() { return stringAttribute.get(this, 'rel'); }
+  set rel(value) { stringAttribute.set(this, 'rel', value); }
   /* c8 ignore stop */
 
 }


### PR DESCRIPTION
Resolves #274 