### PR TITLE
Make attribute value and text content escaping more conforming

### DIFF
--- a/cjs/html/title-element.js
+++ b/cjs/html/title-element.js
@@ -1,17 +1,22 @@
 'use strict';
 const {registerHTMLClass} = require('../shared/register-html-class.js');
+const {escapeHtmlTextContent} = require('../shared/text-escaper.js');
+const {ignoreCase} = require('../shared/utils.js');
 
-const {TextElement} = require('./text-element.js');
+const {HTMLElement} = require('./element.js');
 
 const tagName = 'title';
 
 /**
  * @implements globalThis.HTMLTitleElement
  */
-class HTMLTitleElement extends TextElement {
+class HTMLTitleElement extends HTMLElement {
   constructor(ownerDocument, localName = tagName) {
     super(ownerDocument, localName);
   }
+
+  get innerHTML() { return super.innerHTML; }
+  set innerHTML(html) { super.innerHTML = ignoreCase(this) ? escapeHtmlTextContent(html) : html; }
 }
 
 registerHTMLClass(tagName, HTMLTitleElement);

--- a/cjs/interface/attr.js
+++ b/cjs/interface/attr.js
@@ -4,14 +4,12 @@ const {CHANGED, VALUE} = require('../shared/symbols.js');
 const {String, ignoreCase} = require('../shared/utils.js');
 const {attrAsJSON} = require('../shared/jsdon.js');
 const {emptyAttributes} = require('../shared/attributes.js');
+const {escapeHtmlAttributeValue, escapeXmlAttributeValue} = require('../shared/text-escaper.js');
 
 const {attributeChangedCallback: moAttributes} = require('./mutation-observer.js');
 const {attributeChangedCallback: ceAttributes} = require('./custom-element-registry.js');
 
 const {Node} = require('./node.js');
-const {escape} = require('../shared/text-escaper.js');
-
-const QUOTE = /"/g;
 
 /**
  * @implements globalThis.Attr
@@ -46,7 +44,7 @@ class Attr extends Node {
     if (emptyAttributes.has(name) && !value) {
       return ignoreCase(this) ? name : `${name}=""`;
     }
-    const escapedValue = (ignoreCase(this) ? value : escape(value)).replace(QUOTE, '&quot;');
+    const escapedValue = ignoreCase(this) ? escapeHtmlAttributeValue(value) : escapeXmlAttributeValue(value);
     return `${name}="${escapedValue}"`;
   }
 

--- a/cjs/interface/element.js
+++ b/cjs/interface/element.js
@@ -48,7 +48,6 @@ const {ShadowRoot} = require('./shadow-root.js');
 const {NodeList} = require('./node-list.js');
 const {Attr} = require('./attr.js');
 const {Text} = require('./text.js');
-const {escape} = require('../shared/text-escaper.js');
 
 // <utils>
 const attributesHandler = {
@@ -228,7 +227,7 @@ class Element extends ParentNode {
     if (name === 'class')
       return this.className;
     const attribute = this.getAttributeNode(name);
-    return attribute && (ignoreCase(this) ? attribute.value : escape(attribute.value));
+    return attribute && attribute.value;
   }
 
   getAttributeNode(name) {

--- a/cjs/interface/text.js
+++ b/cjs/interface/text.js
@@ -1,7 +1,8 @@
 'use strict';
 const {TEXT_NODE} = require('../shared/constants.js');
 const {VALUE} = require('../shared/symbols.js');
-const {escape} = require('../shared/text-escaper.js');
+const {escapeHtmlTextContent, escapeXmlTextContent} = require('../shared/text-escaper.js');
+const {ignoreCase} = require('../shared/utils.js');
 
 const {CharacterData} = require('./character-data.js');
 
@@ -39,6 +40,6 @@ class Text extends CharacterData {
     return new Text(ownerDocument, data);
   }
 
-  toString() { return escape(this[VALUE]); }
+  toString() { return ignoreCase(this) ? escapeHtmlTextContent(this[VALUE]) : escapeXmlTextContent(this[VALUE]); }
 }
 exports.Text = Text

--- a/cjs/shared/text-escaper.js
+++ b/cjs/shared/text-escaper.js
@@ -1,24 +1,61 @@
 'use strict';
 const {replace} = '';
 
-// escape
-const ca = /[<>&\xA0]/g;
+const htmlAttributeValueCharacters = /["&<>\xA0]/g;
+const xmlAttributeValueCharacters = /[\t\n\r"&<>]/g;
 
-const esca = {
-  '\xA0': '&#160;',
+const htmlTextContentCharacters = /[&<>\xA0]/g;
+const xmlTextContentCharacters = /[&<>]/g;
+
+const characterEntities = {
+  '\t': '&#x9;',
+  '\n': '&#xA;',
+  '\r': '&#xD;',
+  '"': '&quot;',
   '&': '&amp;',
   '<': '&lt;',
-  '>': '&gt;'
+  '>': '&gt;',
+  '\xA0': '&nbsp;'
 };
 
-const pe = m => esca[m];
+const replaceCharacterByEntity = character => characterEntities[character];
 
 /**
- * Safely escape HTML entities such as `&`, `<`, `>` only.
- * @param {string} es the input to safely escape
+ * Safely escape HTML entities such as `"`, `&`, `<`, `>` and U+00A0 NO-BREAK SPACE only.
+ * @param {string} value the input to safely escape
  * @returns {string} the escaped input, and it **throws** an error if
  *  the input type is unexpected, except for boolean and numbers,
  *  converted as string.
  */
-const escape = es => replace.call(es, ca, pe);
-exports.escape = escape;
+const escapeHtmlAttributeValue = value => replace.call(value, htmlAttributeValueCharacters, replaceCharacterByEntity);
+exports.escapeHtmlAttributeValue = escapeHtmlAttributeValue;
+
+/**
+ * Safely escape XML entities such as `\t`, `\n`, `\r`, `"`, `&`, `<` and `>` only.
+ * @param {string} value the input to safely escape
+ * @returns {string} the escaped input, and it **throws** an error if
+ *  the input type is unexpected, except for boolean and numbers,
+ *  converted as string.
+ */
+const escapeXmlAttributeValue = value => replace.call(value, xmlAttributeValueCharacters, replaceCharacterByEntity);
+exports.escapeXmlAttributeValue = escapeXmlAttributeValue;
+
+/**
+ * Safely escape HTML entities such as `&`, `<`, `>` and U+00A0 NO-BREAK SPACE only.
+ * @param {string} content the input to safely escape
+ * @returns {string} the escaped input, and it **throws** an error if
+ *  the input type is unexpected, except for boolean and numbers,
+ *  converted as string.
+ */
+const escapeHtmlTextContent = content => replace.call(content, htmlTextContentCharacters, replaceCharacterByEntity);
+exports.escapeHtmlTextContent = escapeHtmlTextContent;
+
+/**
+ * Safely escape XML entities such as `&`, `<` and `>` only.
+ * @param {string} content the input to safely escape
+ * @returns {string} the escaped input, and it **throws** an error if
+ *  the input type is unexpected, except for boolean and numbers,
+ *  converted as string.
+ */
+const escapeXmlTextContent = content => replace.call(content, xmlTextContentCharacters, replaceCharacterByEntity);
+exports.escapeXmlTextContent = escapeXmlTextContent;

--- a/esm/html/title-element.js
+++ b/esm/html/title-element.js
@@ -1,16 +1,21 @@
 import {registerHTMLClass} from '../shared/register-html-class.js';
+import {escapeHtmlTextContent} from '../shared/text-escaper.js';
+import {ignoreCase} from '../shared/utils.js';
 
-import {TextElement} from './text-element.js';
+import {HTMLElement} from './element.js';
 
 const tagName = 'title';
 
 /**
  * @implements globalThis.HTMLTitleElement
  */
-class HTMLTitleElement extends TextElement {
+class HTMLTitleElement extends HTMLElement {
   constructor(ownerDocument, localName = tagName) {
     super(ownerDocument, localName);
   }
+
+  get innerHTML() { return super.innerHTML; }
+  set innerHTML(html) { super.innerHTML = ignoreCase(this) ? escapeHtmlTextContent(html) : html; }
 }
 
 registerHTMLClass(tagName, HTMLTitleElement);

--- a/esm/interface/attr.js
+++ b/esm/interface/attr.js
@@ -3,14 +3,12 @@ import {CHANGED, VALUE} from '../shared/symbols.js';
 import {String, ignoreCase} from '../shared/utils.js';
 import {attrAsJSON} from '../shared/jsdon.js';
 import {emptyAttributes} from '../shared/attributes.js';
+import {escapeHtmlAttributeValue, escapeXmlAttributeValue} from '../shared/text-escaper.js';
 
 import {attributeChangedCallback as moAttributes} from './mutation-observer.js';
 import {attributeChangedCallback as ceAttributes} from './custom-element-registry.js';
 
 import {Node} from './node.js';
-import {escape} from '../shared/text-escaper.js';
-
-const QUOTE = /"/g;
 
 /**
  * @implements globalThis.Attr
@@ -45,7 +43,7 @@ export class Attr extends Node {
     if (emptyAttributes.has(name) && !value) {
       return ignoreCase(this) ? name : `${name}=""`;
     }
-    const escapedValue = (ignoreCase(this) ? value : escape(value)).replace(QUOTE, '&quot;');
+    const escapedValue = ignoreCase(this) ? escapeHtmlAttributeValue(value) : escapeXmlAttributeValue(value);
     return `${name}="${escapedValue}"`;
   }
 

--- a/esm/interface/element.js
+++ b/esm/interface/element.js
@@ -50,7 +50,6 @@ import {ShadowRoot} from './shadow-root.js';
 import {NodeList} from './node-list.js';
 import {Attr} from './attr.js';
 import {Text} from './text.js';
-import {escape} from '../shared/text-escaper.js';
 
 // <utils>
 const attributesHandler = {
@@ -230,7 +229,7 @@ export class Element extends ParentNode {
     if (name === 'class')
       return this.className;
     const attribute = this.getAttributeNode(name);
-    return attribute && (ignoreCase(this) ? attribute.value : escape(attribute.value));
+    return attribute && attribute.value;
   }
 
   getAttributeNode(name) {

--- a/esm/interface/text.js
+++ b/esm/interface/text.js
@@ -1,6 +1,7 @@
 import {TEXT_NODE} from '../shared/constants.js';
 import {VALUE} from '../shared/symbols.js';
-import {escape} from '../shared/text-escaper.js';
+import {escapeHtmlTextContent, escapeXmlTextContent} from '../shared/text-escaper.js';
+import {ignoreCase} from '../shared/utils.js';
 
 import {CharacterData} from './character-data.js';
 
@@ -38,5 +39,5 @@ export class Text extends CharacterData {
     return new Text(ownerDocument, data);
   }
 
-  toString() { return escape(this[VALUE]); }
+  toString() { return ignoreCase(this) ? escapeHtmlTextContent(this[VALUE]) : escapeXmlTextContent(this[VALUE]); }
 }

--- a/esm/shared/text-escaper.js
+++ b/esm/shared/text-escaper.js
@@ -1,22 +1,56 @@
 const {replace} = '';
 
-// escape
-const ca = /[<>&\xA0]/g;
+const htmlAttributeValueCharacters = /["&<>\xA0]/g;
+const xmlAttributeValueCharacters = /[\t\n\r"&<>]/g;
 
-const esca = {
-  '\xA0': '&#160;',
+const htmlTextContentCharacters = /[&<>\xA0]/g;
+const xmlTextContentCharacters = /[&<>]/g;
+
+const characterEntities = {
+  '\t': '&#x9;',
+  '\n': '&#xA;',
+  '\r': '&#xD;',
+  '"': '&quot;',
   '&': '&amp;',
   '<': '&lt;',
-  '>': '&gt;'
+  '>': '&gt;',
+  '\xA0': '&nbsp;'
 };
 
-const pe = m => esca[m];
+const replaceCharacterByEntity = character => characterEntities[character];
 
 /**
- * Safely escape HTML entities such as `&`, `<`, `>` only.
- * @param {string} es the input to safely escape
+ * Safely escape HTML entities such as `"`, `&`, `<`, `>` and U+00A0 NO-BREAK SPACE only.
+ * @param {string} value the input to safely escape
  * @returns {string} the escaped input, and it **throws** an error if
  *  the input type is unexpected, except for boolean and numbers,
  *  converted as string.
  */
-export const escape = es => replace.call(es, ca, pe);
+export const escapeHtmlAttributeValue = value => replace.call(value, htmlAttributeValueCharacters, replaceCharacterByEntity);
+
+/**
+ * Safely escape XML entities such as `\t`, `\n`, `\r`, `"`, `&`, `<` and `>` only.
+ * @param {string} value the input to safely escape
+ * @returns {string} the escaped input, and it **throws** an error if
+ *  the input type is unexpected, except for boolean and numbers,
+ *  converted as string.
+ */
+export const escapeXmlAttributeValue = value => replace.call(value, xmlAttributeValueCharacters, replaceCharacterByEntity);
+
+/**
+ * Safely escape HTML entities such as `&`, `<`, `>` and U+00A0 NO-BREAK SPACE only.
+ * @param {string} content the input to safely escape
+ * @returns {string} the escaped input, and it **throws** an error if
+ *  the input type is unexpected, except for boolean and numbers,
+ *  converted as string.
+ */
+export const escapeHtmlTextContent = content => replace.call(content, htmlTextContentCharacters, replaceCharacterByEntity);
+
+/**
+ * Safely escape XML entities such as `&`, `<` and `>` only.
+ * @param {string} content the input to safely escape
+ * @returns {string} the escaped input, and it **throws** an error if
+ *  the input type is unexpected, except for boolean and numbers,
+ *  converted as string.
+ */
+export const escapeXmlTextContent = content => replace.call(content, xmlTextContentCharacters, replaceCharacterByEntity);

--- a/test/html/anchor-element.js
+++ b/test/html/anchor-element.js
@@ -6,9 +6,9 @@ const {document} = parseHTML('<a href="https://google.com/?q=1&page=2">click me<
 
 const {lastElementChild: a} = document;
 
-assert(a.toString(), '<a href="https://google.com/?q=1&page=2">click me</a>');
+assert(a.toString(), '<a href="https://google.com/?q=1&amp;page=2">click me</a>');
 a.setAttribute('href', 'https://google.com/?q=1&page=2&test="');
-assert(a.toString(), '<a href="https://google.com/?q=1&page=2&test=&quot;">click me</a>');
+assert(a.toString(), '<a href="https://google.com/?q=1&amp;page=2&amp;test=&quot;">click me</a>');
 a.setAttribute('href', 'https://google.com/?q=asd&lol=<2>"');
 assert(a.href, 'https://google.com/?q=asd&lol=%3C2%3E%22');
 a.setAttribute('href', 'https://google.com/path%20to%20some%20file.pdf');

--- a/test/html/document.js
+++ b/test/html/document.js
@@ -45,7 +45,7 @@ document.title = 'I';
 assert(document.title + document.title + document.title, 'III', 'side-effects detected when inspecting the title');
 
 document.title = '&';
-assert(document.toString(), '<!DOCTYPE html><html><head><title>&</title></head><body></body></html>');
+assert(document.toString(), '<!DOCTYPE html><html><head><title>&amp;</title></head><body></body></html>');
 
 assert(document.all.length, 4);
 assert(document.all[0], document.querySelector('html'));

--- a/test/html/i-frame-element.js
+++ b/test/html/i-frame-element.js
@@ -16,7 +16,7 @@ assert(iframe.src, './test.html', 'Issue #82 - <iframe>.src');
   iframe.srcdoc = `<html><span style="color: red">Test</span></html>`;
   assert(
     document.body.innerHTML,
-    `<iframe srcdoc="<html><span style=&quot;color: red&quot;>Test</span></html>"></iframe>`
+    `<iframe srcdoc="&lt;html&gt;&lt;span style=&quot;color: red&quot;&gt;Test&lt;/span&gt;&lt;/html&gt;"></iframe>`
   );
 }
 
@@ -50,7 +50,7 @@ assert(iframe.src, './test.html', 'Issue #82 - <iframe>.src');
 {
   const { document } = parseHTML(
    `<html><body><iframe loading="lazy" referrerpolicy="no-referrer" name="iframe-name" allow="geolocation"></iframe></body></html>`
-  ); 
+  );
 
   const iframe = document.body.querySelector("iframe");
   assert(iframe.allowFullscreen, false);

--- a/test/html/meta-element.js
+++ b/test/html/meta-element.js
@@ -24,7 +24,7 @@ assert(b.charset, 'utf-8');
 const {document: httpEquivRefresh} = parseHTML('<meta http-equiv="refresh" content="0; url=https://google.com/?q=1&page=2">');
 const {lastElementChild: c} = httpEquivRefresh;
 // assert toString
-assert(c.toString(), '<meta http-equiv="refresh" content="0; url=https://google.com/?q=1&page=2">');
+assert(c.toString(), '<meta http-equiv="refresh" content="0; url=https://google.com/?q=1&amp;page=2">');
 // assert httpEquiv & content attribute
 assert(c.httpEquiv, 'refresh');
 assert(c.content, '0; url=https://google.com/?q=1&page=2');

--- a/test/html/title-element.js
+++ b/test/html/title-element.js
@@ -1,0 +1,39 @@
+const assert = require('../assert.js').for('HTMLTitleElement');
+
+const {DOMParser, parseHTML} = global[Symbol.for('linkedom')];
+
+const {document: htmlDoc} = parseHTML('<title>abc&<>"\t\n\r\xA0</title>');
+assert(
+  htmlDoc.toString(),
+  '<title>abc&amp;&lt;&gt;"\t\n\r&nbsp;</title>'
+);
+
+const htmlTitle = htmlDoc.querySelector('title');
+htmlTitle.innerHTML = '<a>sub element</a>';
+assert(
+  htmlTitle.innerHTML,
+  '&lt;a&gt;sub element&lt;/a&gt;'
+);
+assert(
+  htmlDoc.toString(),
+  '<title>&lt;a&gt;sub element&lt;/a&gt;</title>'
+);
+assert(htmlDoc.querySelectorAll('a').length, 0);
+
+const xmlDoc = (new DOMParser).parseFromString('<title>abc&<>"\t\n\r\xA0</title>', 'text/xml');
+assert(
+  xmlDoc.toString(),
+  '<?xml version="1.0" encoding="utf-8"?><title>abc&amp;&lt;&gt;"\t\n\r\xA0</title>'
+);
+
+const xmlTitle = xmlDoc.querySelector('title');
+xmlTitle.innerHTML = '<a>sub element</a>';
+assert(
+  xmlTitle.innerHTML,
+  '<a>sub element</a>'
+);
+assert(
+  xmlDoc.toString(),
+  '<?xml version="1.0" encoding="utf-8"?><title><a>sub element</a></title>'
+);
+assert(xmlDoc.querySelectorAll('a').length, 1);

--- a/test/interface/attr.js
+++ b/test/interface/attr.js
@@ -20,11 +20,18 @@ assert(attributes.removeNamedItem('test'), void 0, 'removeNamedItem');
 assert(attributes.item(0), null, 'attributes.item()');
 assert(attributes.setNamedItem(attr), void 0, 'setNamedItem');
 
+const {document: htmlDoc} = parseHTML('<element attr="&lt;a&quot;b&quot;c&gt;\t\n\r&#160;"></element>');
+
+assert(htmlDoc.toString(), '<element attr="&lt;a&quot;b&quot;c&gt;\t\n\r&nbsp;"></element>');
+assert(htmlDoc.firstElementChild.toString(), '<element attr="&lt;a&quot;b&quot;c&gt;\t\n\r&nbsp;"></element>');
+assert(htmlDoc.firstElementChild.outerHTML, '<element attr="&lt;a&quot;b&quot;c&gt;\t\n\r&nbsp;"></element>');
+assert(htmlDoc.firstElementChild.attributes.attr.value, '<a"b"c>\t\n\r\xA0');
+
 /** @type {(str: string) => Document} */
 const parseXML = xmlStr => new DOMParser().parseFromString(xmlStr, 'text/xml');
-const xmlDoc = parseXML('<element attr="a&quot;b&quot;c"></element>');
+const xmlDoc = parseXML('<element attr="&lt;a&quot;b&quot;c&gt;\t\n\r&#160;"></element>');
 
-assert(xmlDoc.toString(), '<?xml version="1.0" encoding="utf-8"?><element attr="a&quot;b&quot;c" />');
-assert(xmlDoc.firstElementChild.toString(), '<element attr="a&quot;b&quot;c" />');
-assert(xmlDoc.firstElementChild.outerHTML, '<element attr="a&quot;b&quot;c" />');
-assert(xmlDoc.firstElementChild.attributes.attr.value, 'a"b"c');
+assert(xmlDoc.toString(), '<?xml version="1.0" encoding="utf-8"?><element attr="&lt;a&quot;b&quot;c&gt;&#x9;&#xA;&#xD;\xA0" />');
+assert(xmlDoc.firstElementChild.toString(), '<element attr="&lt;a&quot;b&quot;c&gt;&#x9;&#xA;&#xD;\xA0" />');
+assert(xmlDoc.firstElementChild.outerHTML, '<element attr="&lt;a&quot;b&quot;c&gt;&#x9;&#xA;&#xD;\xA0" />');
+assert(xmlDoc.firstElementChild.attributes.attr.value, '<a"b"c>\t\n\r\xA0');

--- a/test/interface/element.js
+++ b/test/interface/element.js
@@ -23,8 +23,8 @@ const parser = new DOMParser();
 const htmlDoc = parser.parseFromString(`<div><span content-desc="text3&amp;more"/></div>`, 'text/html').documentElement;
 
 assert(htmlDoc.firstChild.getAttribute('content-desc'), 'text3&more');
-assert(htmlDoc.firstChild.outerHTML, '<span content-desc="text3&more"></span>');
-assert(htmlDoc.innerHTML, '<span content-desc="text3&more"></span>');
+assert(htmlDoc.firstChild.outerHTML, '<span content-desc="text3&amp;more"></span>');
+assert(htmlDoc.innerHTML, '<span content-desc="text3&amp;more"></span>');
 
 htmlDoc.firstChild.setAttribute('content-desc', ''); // attribute is not in emptyAttributes set is empty
 assert(htmlDoc.firstChild.getAttribute('content-desc'), '');
@@ -39,7 +39,7 @@ assert(htmlDocWithEmptyAttrFromSet.innerHTML, '<span></span>');
 
 const xmlDoc = parser.parseFromString(`<hierarchy><android.view.View content-desc="text3&amp;more"/></hierarchy>`, 'text/xml').documentElement;
 
-assert(xmlDoc.firstChild.getAttribute('content-desc'), 'text3&amp;more');
+assert(xmlDoc.firstChild.getAttribute('content-desc'), 'text3&more');
 assert(xmlDoc.firstChild.outerHTML, '<android.view.View content-desc="text3&amp;more" />');
 assert(xmlDoc.innerHTML, '<android.view.View content-desc="text3&amp;more" />');
 

--- a/test/shared/text-escaper.js
+++ b/test/shared/text-escaper.js
@@ -1,19 +1,32 @@
 const BODY = '<body>Foo&#160;&quot;&#160;&quot;&#160;Bar</body>';
-const REBODY = '<body>Foo&nbsp;"&nbsp;"&nbsp;Bar</body>';
+const REBODY_IN_HTML = '<body>Foo&nbsp;"&nbsp;"&nbsp;Bar</body>';
+const REBODY_IN_XML = '<body>Foo\xA0"\xA0"\xA0Bar</body>';
 const HTML = `<html id="html" class="live">${BODY}</html>`;
-const REHTML = `<html id="html" class="live">${REBODY}</html>`;
+const REHTML_IN_HTML = `<html id="html" class="live">${REBODY_IN_HTML}</html>`;
+const REHTML_IN_XML = `<html id="html" class="live">${REBODY_IN_XML}</html>`;
 
 const assert = require('../assert.js').for('Text Escaper');
 
-const {parseHTML} = global[Symbol.for('linkedom')];
+const {parseHTML, DOMParser} = global[Symbol.for('linkedom')];
 
-const {document} = parseHTML('<!DOCTYPE html>' + HTML);
+let {document} = parseHTML('<!DOCTYPE html>' + HTML);
 
-assert(document.documentElement.toString(), REHTML);
+assert(document.documentElement.toString(), REHTML_IN_HTML);
 
 document.documentElement.innerHTML = BODY;
 
-assert(document.documentElement.toString(), REHTML);
+assert(document.documentElement.toString(), REHTML_IN_HTML);
+
+document.documentElement.innerHTML = '<body>&amp;amp;</body>';
+assert(document.documentElement.toString(), `<html id="html" class="live"><body>&amp;amp;</body></html>`);
+
+document = (new DOMParser).parseFromString('<!DOCTYPE html>' + HTML, 'text/xml');
+
+assert(document.documentElement.toString(), REHTML_IN_XML);
+
+document.documentElement.innerHTML = BODY;
+
+assert(document.documentElement.toString(), REHTML_IN_XML);
 
 document.documentElement.innerHTML = '<body>&amp;amp;</body>';
 assert(document.documentElement.toString(), `<html id="html" class="live"><body>&amp;amp;</body></html>`);

--- a/test/shared/text-escaper.js
+++ b/test/shared/text-escaper.js
@@ -1,5 +1,5 @@
 const BODY = '<body>Foo&#160;&quot;&#160;&quot;&#160;Bar</body>';
-const REBODY = BODY.replace(/&quot;/g, '"');
+const REBODY = '<body>Foo&nbsp;"&nbsp;"&nbsp;Bar</body>';
 const HTML = `<html id="html" class="live">${BODY}</html>`;
 const REHTML = `<html id="html" class="live">${REBODY}</html>`;
 
@@ -17,4 +17,3 @@ assert(document.documentElement.toString(), REHTML);
 
 document.documentElement.innerHTML = '<body>&amp;amp;</body>';
 assert(document.documentElement.toString(), `<html id="html" class="live"><body>&amp;amp;</body></html>`);
-

--- a/types/esm/html/title-element.d.ts
+++ b/types/esm/html/title-element.d.ts
@@ -1,6 +1,6 @@
 /**
  * @implements globalThis.HTMLTitleElement
  */
-export class HTMLTitleElement extends TextElement implements globalThis.HTMLTitleElement {
+export class HTMLTitleElement extends HTMLElement implements globalThis.HTMLTitleElement {
 }
-import { TextElement } from './text-element.js';
+import { HTMLElement } from './element.js';

--- a/types/esm/shared/text-escaper.d.ts
+++ b/types/esm/shared/text-escaper.d.ts
@@ -1,1 +1,4 @@
-export function escape(es: string): string;
+export function escapeHtmlAttributeValue(value: string): string;
+export function escapeXmlAttributeValue(value: string): string;
+export function escapeHtmlTextContent(content: string): string;
+export function escapeXmlTextContent(content: string): string;

--- a/worker.js
+++ b/worker.js
@@ -11405,10 +11405,13 @@ const tagName$9 = 'title';
 /**
  * @implements globalThis.HTMLTitleElement
  */
-class HTMLTitleElement extends TextElement {
+class HTMLTitleElement extends HTMLElement {
   constructor(ownerDocument, localName = tagName$9) {
     super(ownerDocument, localName);
   }
+
+  get innerHTML() { return super.innerHTML; }
+  set innerHTML(html) { super.innerHTML = ignoreCase(this) ? escapeHtmlTextContent(html) : html; }
 }
 
 registerHTMLClass(tagName$9, HTMLTitleElement);


### PR DESCRIPTION
Fixes #216
Supersedes and closes #217

The HTML spec defines which characters to escape when [serializing HTML](https://html.spec.whatwg.org/multipage/parsing.html#escapingString). This got changed recently to also serialize `<` and `>` in attribute values.

This aligns with the DOM Parsing and Serialization spec which defines its own rule for [escaping attribute values](https://w3c.github.io/DOM-Parsing/#dfn-serializing-an-attribute-value) and for [escaping text nodes](https://w3c.github.io/DOM-Parsing/#dfn-xml-serializing-a-text-node), both requiring these two characters to always be escaped.

HTML also requires non-breaking spaces to be escaped (in HTML).
Also browsers de facto serialize tabs, line feeds and carriage returns in attribute values in XML (there is no spec for this, but there is a [web platform test](https://github.com/web-platform-tests/wpt/blob/master/domparsing/XMLSerializer-serializeToString.html#L155)). JSDOM does this too.

This PR implements those requirements.

This PR also brings another fix about `<title>` elements which used to be considered a special case when serializing in this codebase, while i couldn't find anything in the spec about this (the `<title>` element is not in [this list](https://html.spec.whatwg.org/multipage/parsing.html#serialising-html-fragments:text)). Instead, we customize its `innerHTML` setter to escape everything, which prevents child elements to be added to them through this property (for HTML documents only). 
