### PR TITLE
Fixes how empty XHTML and SVG elements are serialized

### DIFF
--- a/cjs/dom/parser.js
+++ b/cjs/dom/parser.js
@@ -27,7 +27,7 @@ class DOMParser {
     else if (mimeType === 'image/svg+xml')
       document = new SVGDocument;
     else
-      document = new XMLDocument;
+      document = new XMLDocument(mimeType);
     document[DOM_PARSER] = DOMParser;
     if (globals)
       document[GLOBALS] = globals;

--- a/cjs/interface/element.js
+++ b/cjs/interface/element.js
@@ -459,7 +459,7 @@ class Element extends ParentNode {
           const start = next[START];
           if (isOpened) {
             if ('ownerSVGElement' in start)
-              out.push(' />');
+              out.push('/>');
             else if (isVoid(start))
               out.push(ignoreCase(start) ? '>' : ' />');
             else

--- a/cjs/shared/mime.js
+++ b/cjs/shared/mime.js
@@ -27,7 +27,7 @@ const Mime = {
   'application/xhtml+xml': {
     docType: '<?xml version="1.0" encoding="utf-8"?>',
     ignoreCase: false,
-    voidElements
+    voidElements: /^(?:area|base|br|col|embed|hr|img|input|keygen|link|menuitem|meta|param|source|track|wbr)$/
   }
 };
 exports.Mime = Mime;

--- a/cjs/xml/document.js
+++ b/cjs/xml/document.js
@@ -6,7 +6,7 @@ const {Document} = require('../interface/document.js');
  * @implements globalThis.XMLDocument
  */
 class XMLDocument extends Document {
-  constructor() { super('text/xml'); }
+  constructor(mimeType = 'text/xml') { super(mimeType); }
   toString() {
     return this[MIME].docType + super.toString();
   }

--- a/esm/dom/parser.js
+++ b/esm/dom/parser.js
@@ -26,7 +26,7 @@ export class DOMParser {
     else if (mimeType === 'image/svg+xml')
       document = new SVGDocument;
     else
-      document = new XMLDocument;
+      document = new XMLDocument(mimeType);
     document[DOM_PARSER] = DOMParser;
     if (globals)
       document[GLOBALS] = globals;

--- a/esm/interface/element.js
+++ b/esm/interface/element.js
@@ -461,7 +461,7 @@ export class Element extends ParentNode {
           const start = next[START];
           if (isOpened) {
             if ('ownerSVGElement' in start)
-              out.push(' />');
+              out.push('/>');
             else if (isVoid(start))
               out.push(ignoreCase(start) ? '>' : ' />');
             else

--- a/esm/shared/mime.js
+++ b/esm/shared/mime.js
@@ -26,6 +26,6 @@ export const Mime = {
   'application/xhtml+xml': {
     docType: '<?xml version="1.0" encoding="utf-8"?>',
     ignoreCase: false,
-    voidElements
+    voidElements: /^(?:area|base|br|col|embed|hr|img|input|keygen|link|menuitem|meta|param|source|track|wbr)$/
   }
 };

--- a/esm/xml/document.js
+++ b/esm/xml/document.js
@@ -5,7 +5,7 @@ import {Document} from '../interface/document.js';
  * @implements globalThis.XMLDocument
  */
 export class XMLDocument extends Document {
-  constructor() { super('text/xml'); }
+  constructor(mimeType = 'text/xml') { super(mimeType); }
   toString() {
     return this[MIME].docType + super.toString();
   }

--- a/test/shared/parse-json.js
+++ b/test/shared/parse-json.js
@@ -35,7 +35,7 @@ let div = parseJSON('[1,"div",1,"svg",1,"rect",-2,1,"c-e",-2]');
 
 assert(JSON.stringify(toJSON(div)), '[1,"div",1,"svg",1,"rect",-2,1,"c-e",-2]');
 
-assert(div.toString(), '<div><svg><rect /></svg><c-e></c-e></div>');
+assert(div.toString(), '<div><svg><rect/></svg><c-e></c-e></div>');
 
 assert(div.querySelector('c-e').constructed, void 0, 'not constructed');
 

--- a/test/svg/element.js
+++ b/test/svg/element.js
@@ -16,8 +16,8 @@ assert(svg instanceof SVGElement, true, '<svg> is an instance of a facade');
 assert('ownerSVGElement' in svg, true, '<svg> ownerSVGElement');
 assert(svg.ownerSVGElement, null, '<svg> ownerSVGElement is null');
 assert(svg.firstChild.ownerSVGElement, svg, '<rect> has an ownerSVGElement');
-assert(document.toString(), '<div><svg><rect /></svg></div>', 'svg nodes are OK');
-assert(document.documentElement.cloneNode(true).outerHTML, '<div><svg><rect /></svg></div>', 'svg cloned');
+assert(document.toString(), '<div><svg><rect/></svg></div>', 'svg nodes are OK');
+assert(document.documentElement.cloneNode(true).outerHTML, '<div><svg><rect/></svg></div>', 'svg cloned');
 
 assert(JSON.stringify(document), '[9,1,"div",1,"svg",1,"rect",-4]');
 assert(JSON.stringify(svg), '[1,"svg",1,"rect",-2]');
@@ -39,7 +39,7 @@ assert(svg.className.what, 'ever', '<svg>.className');
 svg.setAttribute('test', 123);
 svg.setAttribute('style', 'width:100px');
 
-assert(svg.toString(), '<svg style="width:100px" test="123"><rect /></svg>');
+assert(svg.toString(), '<svg style="width:100px" test="123"><rect/></svg>');
 
 svg.className = 'a b c';
 assert(svg.getAttribute('class'), 'a b c');

--- a/test/worker.js
+++ b/test/worker.js
@@ -3,6 +3,6 @@ import createAssert from './assert-es.js';
 
 const assert = createAssert.for('Web Worker');
 
-let {document} = parseHTML('<div><svg><rect /></svg></div>');
+let {document} = parseHTML('<div><svg><rect/></svg></div>');
 
 assert(document.querySelector('div').firstChild.localName, 'svg', 'Should be an svg element in the div');

--- a/types/esm/shared/mime.d.ts
+++ b/types/esm/shared/mime.d.ts
@@ -28,8 +28,6 @@ export const Mime: {
     'application/xhtml+xml': {
         docType: string;
         ignoreCase: boolean;
-        voidElements: {
-            test: () => boolean;
-        };
+        voidElements: RegExp;
     };
 };

--- a/types/esm/xml/document.d.ts
+++ b/types/esm/xml/document.d.ts
@@ -2,6 +2,6 @@
  * @implements globalThis.XMLDocument
  */
 export class XMLDocument extends Document implements globalThis.XMLDocument {
-    constructor();
+    constructor(mimeType?: string);
 }
 import { Document } from '../interface/document.js';

--- a/worker.js
+++ b/worker.js
@@ -8046,7 +8046,7 @@ let Element$1 = class Element extends ParentNode {
           const start = next[START];
           if (isOpened) {
             if ('ownerSVGElement' in start)
-              out.push(' />');
+              out.push('/>');
             else if (isVoid(start))
               out.push(ignoreCase(start) ? '>' : ' />');
             else

--- a/worker.js
+++ b/worker.js
@@ -11992,7 +11992,7 @@ const Mime = {
   'application/xhtml+xml': {
     docType: '<?xml version="1.0" encoding="utf-8"?>',
     ignoreCase: false,
-    voidElements
+    voidElements: /^(?:area|base|br|col|embed|hr|img|input|keygen|link|menuitem|meta|param|source|track|wbr)$/
   }
 };
 

--- a/worker.js
+++ b/worker.js
@@ -12578,7 +12578,7 @@ class SVGDocument extends Document$1 {
  * @implements globalThis.XMLDocument
  */
 class XMLDocument extends Document$1 {
-  constructor() { super('text/xml'); }
+  constructor(mimeType = 'text/xml') { super(mimeType); }
   toString() {
     return this[MIME].docType + super.toString();
   }
@@ -12605,7 +12605,7 @@ class DOMParser {
     else if (mimeType === 'image/svg+xml')
       document = new SVGDocument;
     else
-      document = new XMLDocument;
+      document = new XMLDocument(mimeType);
     document[DOM_PARSER] = DOMParser;
     if (globals)
       document[GLOBALS] = globals;


### PR DESCRIPTION
The DOM Parsing and Serialization spec defines that only some empty elements should be autoclosed when serializing XHTML: https://w3c.github.io/DOM-Parsing/#ref-for-dfn-html-namespace-3 . This PR aligns with this spec.

It also tells that among empty elements, only those ones get a space before the slash (`<link />` instead of `<link/>`). As such, SVG elements should not have a space for example (`<rect/>` instead of `<rect />`). This implements such change. Ideally it should also be applied on other XML documents, but i wanted to keep things simple and not too invasive for the codebase.