### PR TITLE
HTMLTemplateElement innerHTML output bugfix

### DIFF
--- a/esm/html/template-element.js
+++ b/esm/html/template-element.js
@@ -4,6 +4,8 @@ import {registerHTMLClass} from '../shared/register-html-class.js';
 
 import {HTMLElement} from './element.js';
 
+import {getInnerHtml} from '../mixin/inner-html.js'
+
 const tagName = 'template';
 
 /**
@@ -16,6 +18,9 @@ class HTMLTemplateElement extends HTMLElement {
     (this[CONTENT] = content)[PRIVATE] = this;
   }
 
+  get innerHTML() {
+    return getInnerHtml(this.content);
+  }
   get content() {
     if (this.hasChildNodes() && !this[CONTENT].hasChildNodes()) {
       for (const node of this.childNodes)


### PR DESCRIPTION
--browser result--
```javascript
// --browser result--
const f = document.createDocumentFragment();
const d = document.createElement('div')
d.innerHTML='<a>aaa</a>';
f.append(d);
const t = document.createElement('template');
t.content.append(f);
console.log(t.innerHTML); // '<div><a>aaa</a></div>'
console.log(t.innerText); //''

```
<img width="373" height="204" alt="image" src="https://github.com/user-attachments/assets/453106a0-f374-49b2-b33b-8c9c92a4f6c6" />

--linkedom--
```typescript
console.log(t.innerHTML); // ''
console.log(t.innerText); //''
```

bugfix