### PR TITLE
HTMLTemplateElement innerHTML output bugfix (cjs, esm)

### DIFF
--- a/cjs/html/template-element.js
+++ b/cjs/html/template-element.js
@@ -5,6 +5,8 @@ const {registerHTMLClass} = require('../shared/register-html-class.js');
 
 const {HTMLElement} = require('./element.js');
 
+import {getInnerHtml} from '../mixin/inner-html.js'
+
 const tagName = 'template';
 
 /**
@@ -15,6 +17,10 @@ class HTMLTemplateElement extends HTMLElement {
     super(ownerDocument, tagName);
     const content = this.ownerDocument.createDocumentFragment();
     (this[CONTENT] = content)[PRIVATE] = this;
+  }
+
+  get innerHTML() {
+    return getInnerHtml(this.content);
   }
 
   get content() {

--- a/esm/html/template-element.js
+++ b/esm/html/template-element.js
@@ -4,6 +4,8 @@ import {registerHTMLClass} from '../shared/register-html-class.js';
 
 import {HTMLElement} from './element.js';
 
+import {getInnerHtml} from '../mixin/inner-html.js'
+
 const tagName = 'template';
 
 /**
@@ -14,6 +16,10 @@ class HTMLTemplateElement extends HTMLElement {
     super(ownerDocument, tagName);
     const content = this.ownerDocument.createDocumentFragment();
     (this[CONTENT] = content)[PRIVATE] = this;
+  }
+
+  get innerHTML() {
+    return getInnerHtml(this.content);
   }
 
   get content() {


### PR DESCRIPTION
--browser result--
```javascript
const f = document.createDocumentFragment();
const d = document.createElement('div')
d.innerHTML='<a>aaa</a>';
f.append(d);
const t = document.createElement('template');
t.content.append(f);
console.log(t.innerHTML); // '<div><a>aaa</a></div>'
console.log(t.innerText); //''
```
<img width="349" height="193" alt="image" src="https://github.com/user-attachments/assets/ded7eedf-90d8-4790-a473-998b15273212" />



--linkedom--
```typescript
console.log(t.innerHTML); //''
console.log(t.innerText); //''
```
After appending the child element to the HTML Template Element's content If you do innerHTML, it is normal to output the contents of the child element, but it is not output in linkedom.

bugfix