### PR TITLE
fix: reading an unset style property returns "" per CSSOM, not undefined

### DIFF
--- a/cjs/interface/css-style-declaration.js
+++ b/cjs/interface/css-style-declaration.js
@@ -36,7 +36,10 @@ const handler = {
       return getKeys(style).length;
     if (/^\d+$/.test(name))
       return getKeys(style)[name];
-    return style.get(uhyphen(name));
+    // Per CSSOM, reading a property that is not set returns the empty string,
+    // not undefined (which also matches getPropertyValue, routed here).
+    const value = style.get(uhyphen(name));
+    return value === void 0 ? '' : value;
   },
 
   set(style, name, value) {

--- a/cjs/interface/css-style-declaration.js
+++ b/cjs/interface/css-style-declaration.js
@@ -36,10 +36,7 @@ const handler = {
       return getKeys(style).length;
     if (/^\d+$/.test(name))
       return getKeys(style)[name];
-    // Per CSSOM, reading a property that is not set returns the empty string,
-    // not undefined (which also matches getPropertyValue, routed here).
-    const value = style.get(uhyphen(name));
-    return value === void 0 ? '' : value;
+    return style.get(uhyphen(name)) ?? '';
   },
 
   set(style, name, value) {

--- a/esm/interface/css-style-declaration.js
+++ b/esm/interface/css-style-declaration.js
@@ -35,10 +35,7 @@ const handler = {
       return getKeys(style).length;
     if (/^\d+$/.test(name))
       return getKeys(style)[name];
-    // Per CSSOM, reading a property that is not set returns the empty string,
-    // not undefined (which also matches getPropertyValue, routed here).
-    const value = style.get(uhyphen(name));
-    return value === void 0 ? '' : value;
+    return style.get(uhyphen(name)) ?? '';
   },
 
   set(style, name, value) {

--- a/esm/interface/css-style-declaration.js
+++ b/esm/interface/css-style-declaration.js
@@ -35,7 +35,10 @@ const handler = {
       return getKeys(style).length;
     if (/^\d+$/.test(name))
       return getKeys(style)[name];
-    return style.get(uhyphen(name));
+    // Per CSSOM, reading a property that is not set returns the empty string,
+    // not undefined (which also matches getPropertyValue, routed here).
+    const value = style.get(uhyphen(name));
+    return value === void 0 ? '' : value;
   },
 
   set(style, name, value) {

--- a/test/interface/css-style-declaration.js
+++ b/test/interface/css-style-declaration.js
@@ -6,6 +6,10 @@ const {document} = parseHTML('');
 
 let node = document.createElement('div');
 assert(node.style.cssText, '', 'empty style');
+// Per CSSOM, an unset property reads as the empty string, not undefined —
+// matching getPropertyValue, which is routed through the same getter.
+assert(node.style.color, '', 'unset property getter returns ""');
+assert(node.style.getPropertyValue('color'), '', 'unset getPropertyValue returns ""');
 node.style.cssText = 'background-color: blue; background-image: url("https://t.co/i.png");';
 assert(node.style.backgroundColor, 'blue', 'style getter');
 assert(node.style.backgroundImage, 'url("https://t.co/i.png")', 'style value with colon');


### PR DESCRIPTION
## Problem

Reading a style property that isn't set returns `undefined`, but per [CSSOM](https://drafts.csswg.org/cssom/#dom-cssstyledeclaration-getpropertyvalue) both the camel-cased property getter and `getPropertyValue()` must return the **empty string** for an unset property.

```js
import { parseHTML } from "linkedom";
const { document } = parseHTML("<!doctype html><html><body></body></html>");
const el = document.createElement("p");

el.style.color;                         // => undefined   (browser: "")
el.style.getPropertyValue("color");     // => undefined   (browser: "")
```

Because the property getter is routed through the same handler as `getPropertyValue`, both are affected. Code that assumes the spec — e.g. `el.style.color.replaceAll(...)` or any string method — throws `Cannot read properties of undefined` on an element that simply hasn't set that property. This bites libraries that parse arbitrary HTML and read inline styles (ProseMirror's DOMParser, etc.).

## Fix

Normalize an absent property to `""` in the style getter (`esm/interface/css-style-declaration.js`), which also covers `getPropertyValue`. Setting/removing/serialization are untouched; a set property still returns its value, and `cssText` is unchanged.

```js
const value = style.get(uhyphen(name));
return value === void 0 ? '' : value;
```

CJS is regenerated via `npm run cjs`. A test is added in `test/interface/css-style-declaration.js`; the full suite (`node test/index.js`) passes.

## Not a duplicate

Distinct from the open CSS issues:
- #318 replaces the CSSOM library for parsing `<style>` sheets (`element.sheet`), not the inline `element.style` declaration.
- #327 concerns *setting* an empty string (delete semantics), not *reading* an unset property.
