### PR TITLE
Fix #329 - stack foreignobjects within SVGs

### DIFF
--- a/cjs/shared/parse-from-string.js
+++ b/cjs/shared/parse-from-string.js
@@ -43,8 +43,10 @@ exports.isNotParsing = isNotParsing;
 const parseFromString = (document, isHTML, markupLanguage) => {
   const {active, registry} = document[CUSTOM_ELEMENTS];
 
+  const foreignObjects = [];
+  const ownerSVGElements = [];
+
   let node = document;
-  let ownerSVGElement = null;
   let parsingCData = false;
 
   notParsing = false;
@@ -60,14 +62,17 @@ const parseFromString = (document, isHTML, markupLanguage) => {
     onopentag(name, attributes) {
       let create = true;
       if (isHTML) {
-        if (ownerSVGElement) {
+        const { length: slength } = ownerSVGElements;
+        const { length: flength } = foreignObjects;
+        if (slength && (!flength || (foreignObjects[flength - 1].ownerSVGElement !== ownerSVGElements[slength - 1]))) {
           node = append(node, document.createElementNS(SVG_NAMESPACE, name), active);
-          node.ownerSVGElement = ownerSVGElement;
+          node.ownerSVGElement = ownerSVGElements[slength - 1];
+          if (name === 'foreignobject' || name === 'FOREIGNOBJECT') foreignObjects.push(node);
           create = false;
         }
         else if (name === 'svg' || name === 'SVG') {
-          ownerSVGElement = document.createElementNS(SVG_NAMESPACE, name);
-          node = append(node, ownerSVGElement, active);
+          node = append(node, document.createElementNS(SVG_NAMESPACE, name), active);
+          ownerSVGElements[slength] = node;
           create = false;
         }
         else if (active) {
@@ -105,8 +110,10 @@ const parseFromString = (document, isHTML, markupLanguage) => {
 
     // </tagName>
     onclosetag() {
-      if (isHTML && node === ownerSVGElement)
-        ownerSVGElement = null;
+      if (isHTML) {
+        pop(node, ownerSVGElements);
+        pop(node, foreignObjects);
+      }
       node = node.parentNode;
     }
   }, {
@@ -123,3 +130,9 @@ const parseFromString = (document, isHTML, markupLanguage) => {
   return document;
 };
 exports.parseFromString = parseFromString;
+
+const pop = (node, list) => {
+  let { length } = list;
+  if (length && node === list[length - 1])
+    list.pop();
+};

--- a/esm/shared/parse-from-string.js
+++ b/esm/shared/parse-from-string.js
@@ -41,8 +41,10 @@ export const isNotParsing = () => notParsing;
 export const parseFromString = (document, isHTML, markupLanguage) => {
   const {active, registry} = document[CUSTOM_ELEMENTS];
 
+  const foreignObjects = [];
+  const ownerSVGElements = [];
+
   let node = document;
-  let ownerSVGElement = null;
   let parsingCData = false;
 
   notParsing = false;
@@ -58,14 +60,17 @@ export const parseFromString = (document, isHTML, markupLanguage) => {
     onopentag(name, attributes) {
       let create = true;
       if (isHTML) {
-        if (ownerSVGElement) {
+        const { length: slength } = ownerSVGElements;
+        const { length: flength } = foreignObjects;
+        if (slength && (!flength || (foreignObjects[flength - 1].ownerSVGElement !== ownerSVGElements[slength - 1]))) {
           node = append(node, document.createElementNS(SVG_NAMESPACE, name), active);
-          node.ownerSVGElement = ownerSVGElement;
+          node.ownerSVGElement = ownerSVGElements[slength - 1];
+          if (name === 'foreignobject' || name === 'FOREIGNOBJECT') foreignObjects.push(node);
           create = false;
         }
         else if (name === 'svg' || name === 'SVG') {
-          ownerSVGElement = document.createElementNS(SVG_NAMESPACE, name);
-          node = append(node, ownerSVGElement, active);
+          node = append(node, document.createElementNS(SVG_NAMESPACE, name), active);
+          ownerSVGElements[slength] = node;
           create = false;
         }
         else if (active) {
@@ -103,8 +108,10 @@ export const parseFromString = (document, isHTML, markupLanguage) => {
 
     // </tagName>
     onclosetag() {
-      if (isHTML && node === ownerSVGElement)
-        ownerSVGElement = null;
+      if (isHTML) {
+        pop(node, ownerSVGElements);
+        pop(node, foreignObjects);
+      }
       node = node.parentNode;
     }
   }, {
@@ -119,4 +126,10 @@ export const parseFromString = (document, isHTML, markupLanguage) => {
   notParsing = true;
 
   return document;
+};
+
+const pop = (node, list) => {
+  let { length } = list;
+  if (length && node === list[length - 1])
+    list.pop();
 };

--- a/test/svg/document.js
+++ b/test/svg/document.js
@@ -12,3 +12,10 @@ try {
   assert(false, true, 'facades should not be instantiable');
 }
 catch (OK) {}
+
+
+const {parseHTML} = global[Symbol.for('linkedom')];
+
+const html = '<svg><foreignObject><div></div><span>x</span></foreignObject></svg>';
+
+assert(parseHTML(html).document.toString().includes('<div></div>'), true, 'foreignObject');

--- a/worker.js
+++ b/worker.js
@@ -2272,8 +2272,10 @@ const attribute = (element, end, attribute, value, active) => {
 const parseFromString = (document, isHTML, markupLanguage) => {
   const {active, registry} = document[CUSTOM_ELEMENTS];
 
+  const foreignObjects = [];
+  const ownerSVGElements = [];
+
   let node = document;
-  let ownerSVGElement = null;
   let parsingCData = false;
 
   const content = new Parser({
@@ -2287,14 +2289,17 @@ const parseFromString = (document, isHTML, markupLanguage) => {
     onopentag(name, attributes) {
       let create = true;
       if (isHTML) {
-        if (ownerSVGElement) {
+        const { length: slength } = ownerSVGElements;
+        const { length: flength } = foreignObjects;
+        if (slength && (!flength || (foreignObjects[flength - 1].ownerSVGElement !== ownerSVGElements[slength - 1]))) {
           node = append$2(node, document.createElementNS(SVG_NAMESPACE, name), active);
-          node.ownerSVGElement = ownerSVGElement;
+          node.ownerSVGElement = ownerSVGElements[slength - 1];
+          if (name === 'foreignobject' || name === 'FOREIGNOBJECT') foreignObjects.push(node);
           create = false;
         }
         else if (name === 'svg' || name === 'SVG') {
-          ownerSVGElement = document.createElementNS(SVG_NAMESPACE, name);
-          node = append$2(node, ownerSVGElement, active);
+          node = append$2(node, document.createElementNS(SVG_NAMESPACE, name), active);
+          ownerSVGElements[slength] = node;
           create = false;
         }
         else if (active) {
@@ -2332,8 +2337,10 @@ const parseFromString = (document, isHTML, markupLanguage) => {
 
     // </tagName>
     onclosetag() {
-      if (isHTML && node === ownerSVGElement)
-        ownerSVGElement = null;
+      if (isHTML) {
+        pop(node, ownerSVGElements);
+        pop(node, foreignObjects);
+      }
       node = node.parentNode;
     }
   }, {
@@ -2346,6 +2353,12 @@ const parseFromString = (document, isHTML, markupLanguage) => {
   content.end();
 
   return document;
+};
+
+const pop = (node, list) => {
+  let { length } = list;
+  if (length && node === list[length - 1])
+    list.pop();
 };
 
 const htmlClasses = new Map;


### PR DESCRIPTION
Fixes https://github.com/WebReflection/linkedom/issues/329

Apparently SVG can contain `foreignObject` which re-enables HTML parsing ... I have no idea if that works within a stack, so that SVG within a foreignObject re-activate SVG and so on and so forth but this implementation does that, although if that's not the case it could be simplified.